### PR TITLE
Add MoGe-3 to model zoo

### DIFF
--- a/fiftyone/utils/moge.py
+++ b/fiftyone/utils/moge.py
@@ -1,0 +1,383 @@
+"""
+`MoGe-3 <https://github.com/microsoft/MoGe>`_ wrapper for the FiftyOne
+Model Zoo.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import logging
+import os
+import numpy as np
+from PIL import Image
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+import torch
+
+logger = logging.getLogger(__name__)
+
+MOGE_COMMIT = "74fbce054ebed49800de42d0ad0e83495065719a"
+
+
+def _ensure_moge():
+    if not fou.ensure_package("moge", error_level=2):
+        fou.install_package(
+            "git+https://github.com/microsoft/MoGe.git@" + MOGE_COMMIT
+        )
+
+
+moge_v3 = fou.lazy_import("moge.model.v3", callback=_ensure_moge)
+
+DEFAULT_MOGE_MODEL = "Ruicheng/moge-3-vitl"
+
+
+def _to_arrays(value):
+    """Converts a batch of per-image outputs to a list of numpy arrays."""
+    if value is None:
+        return None
+
+    if isinstance(value, torch.Tensor):
+        value = value.detach().float().cpu().numpy()
+
+    if isinstance(value, np.ndarray):
+        return (
+            [value]
+            if value.ndim in (2, 3) and _is_single(value)
+            else list(value)
+        )
+
+    return [
+        (
+            v.detach().float().cpu().numpy()
+            if isinstance(v, torch.Tensor)
+            else np.asarray(v)
+        )
+        for v in value
+    ]
+
+
+def _is_single(value):
+    """Whether an array holds one image's output rather than a batch."""
+    return value.ndim == 2 or (value.ndim == 3 and value.shape[-1] in (1, 3))
+
+
+def _resize(array, size, nearest):
+    """Resizes a 2D or HxWxC float array to ``(width, height)``."""
+    resample = (
+        Image.Resampling.NEAREST if nearest else Image.Resampling.BILINEAR
+    )
+    if array.ndim == 2:
+        return np.array(
+            Image.fromarray(array.astype(np.float32)).resize(size, resample)
+        )
+
+    channels = [
+        np.array(
+            Image.fromarray(array[..., c].astype(np.float32)).resize(
+                size, resample
+            )
+        )
+        for c in range(array.shape[-1])
+    ]
+    return np.stack(channels, axis=-1)
+
+
+class MoGeOutputProcessor(fout.OutputProcessor):
+    """Output processor for MoGe-3 models.
+
+    Converts metric depth predictions to :class:`fiftyone.core.labels.Heatmap`
+    instances. Each ``map`` is the depth divided by its maximum, which is kept
+    in ``max_depth`` so metres are recoverable, and ``is_metric`` is set. The
+    predicted valid-pixel mask and the normalized camera intrinsics are
+    attached as ``valid_mask`` and ``intrinsics``; ``normal_map`` and
+    ``point_map`` are attached when the model was configured to return them.
+    """
+
+    def __call__(
+        self,
+        output,
+        frame_size,
+        confidence_thresh=None,
+        classes=None,
+        **kwargs,
+    ):
+        """Processes model output into heatmap labels.
+
+        Args:
+            output: a dict with a ``"depth"`` key holding one depth map per
+                image and optional ``"mask"``, ``"intrinsics"``,
+                ``"normal"`` and ``"points"`` keys
+            frame_size: a ``(width, height)`` tuple
+            **kwargs: additional keyword arguments
+
+        Returns:
+            a list of :class:`fiftyone.core.labels.Heatmap` instances
+        """
+        if not isinstance(output, dict):
+            raise TypeError(
+                "Expected dict output, got %s" % type(output).__name__
+            )
+
+        if "depth" not in output:
+            raise KeyError(
+                "Model output missing 'depth' key. Available: %s"
+                % list(output.keys())
+            )
+
+        depths = _to_arrays(output["depth"])
+        if not depths:
+            raise ValueError("Model output 'depth' is empty")
+
+        masks = _to_arrays(output.get("mask"))
+        normals = _to_arrays(output.get("normal"))
+        points = _to_arrays(output.get("points"))
+        intrinsics = output.get("intrinsics")
+        is_metric = output.get("is_metric", True)
+
+        width, height = frame_size
+        size = (
+            (width, height)
+            if width is not None and height is not None
+            else None
+        )
+
+        results = []
+        for i, depth in enumerate(depths):
+            depth = np.asarray(depth, dtype=np.float32)
+            if depth.ndim == 3:
+                depth = depth[..., 0]
+
+            mask = masks[i] if masks is not None and i < len(masks) else None
+            if mask is not None:
+                mask = np.asarray(mask) > 0
+
+            if not np.all(np.isfinite(depth)):
+                depth = np.where(np.isfinite(depth), depth, 0)
+
+            if mask is not None and mask.shape == depth.shape:
+                depth = np.where(mask, depth, 0)
+
+            if size is not None and depth.shape[:2] != (height, width):
+                depth = _resize(depth, size, nearest=False)
+                if mask is not None:
+                    mask = (
+                        _resize(mask.astype(np.float32), size, nearest=True)
+                        > 0.5
+                    )
+
+            max_depth = float(np.max(depth)) if depth.size else 0.0
+            if max_depth > 0:
+                normalized = depth / max_depth
+            else:
+                logger.warning("Depth map has max value of 0, returning zeros")
+                normalized = np.zeros_like(depth)
+
+            heatmap = fol.Heatmap(map=normalized.astype(np.float32))
+            heatmap.is_metric = bool(is_metric)
+            if is_metric:
+                heatmap.max_depth = max_depth
+
+            if mask is not None:
+                heatmap.valid_mask = mask.astype(np.uint8)
+
+            if intrinsics is not None and i < len(intrinsics):
+                k = intrinsics[i]
+                if isinstance(k, torch.Tensor):
+                    k = k.detach().float().cpu().numpy()
+                heatmap.intrinsics = np.asarray(k, dtype=np.float32).tolist()
+
+            if normals is not None and i < len(normals):
+                normal = np.asarray(normals[i], dtype=np.float32)
+                if size is not None and normal.shape[:2] != (height, width):
+                    normal = _resize(normal, size, nearest=False)
+                heatmap.normal_map = normal
+
+            if points is not None and i < len(points):
+                point_map = np.asarray(points[i], dtype=np.float32)
+                if size is not None and point_map.shape[:2] != (height, width):
+                    point_map = _resize(point_map, size, nearest=False)
+                heatmap.point_map = point_map
+
+            results.append(heatmap)
+
+        return results
+
+
+class MoGeModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`MoGeModel`.
+
+    See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
+    arguments.
+
+    Args:
+        name_or_path ("Ruicheng/moge-3-vitl"): the Hugging Face repo of the
+            MoGe-3 checkpoint, or a path to a local ``model.pt``
+        resolution_level (9): the inference resolution level, 0 to 9. Higher
+            levels use more ViT tokens and keep finer detail
+        num_tokens (None): an explicit number of ViT tokens, which overrides
+            ``resolution_level``
+        refine_steps (3): the number of sparse volumetric refinement steps.
+            Refinement needs a CUDA device; on CPU it is skipped
+        fov_x (None): the horizontal field of view in degrees, when the camera
+            is known. Otherwise it is estimated from the prediction
+        use_fp16 (False): whether to run the encoder in mixed precision
+        include_normals (False): whether to attach the predicted surface
+            normal map to each heatmap
+        include_points (False): whether to attach the camera-space point map
+            to each heatmap
+    """
+
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+
+        self.name_or_path = self.parse_string(
+            d, "name_or_path", default=DEFAULT_MOGE_MODEL
+        )
+        self.resolution_level = self.parse_int(
+            d, "resolution_level", default=9
+        )
+        self.num_tokens = self.parse_int(d, "num_tokens", default=None)
+        self.refine_steps = self.parse_int(d, "refine_steps", default=3)
+        self.fov_x = self.parse_number(d, "fov_x", default=None)
+        self.use_fp16 = self.parse_bool(d, "use_fp16", default=False)
+        self.include_normals = self.parse_bool(
+            d, "include_normals", default=False
+        )
+        self.include_points = self.parse_bool(
+            d, "include_points", default=False
+        )
+
+        self.raw_inputs = True
+
+        if self.output_processor_cls is None:
+            self.output_processor_cls = (
+                "fiftyone.utils.moge.MoGeOutputProcessor"
+            )
+
+
+class MoGeModel(fout.TorchImageModel):
+    """Wrapper for running inference with
+    `MoGe-3 <https://github.com/microsoft/MoGe>`_.
+
+    MoGe-3 predicts metric-scale monocular geometry from a single image: a
+    depth map, a camera-space point map, surface normals, a valid-pixel mask
+    and the camera intrinsics, with a sparse volumetric refinement stage that
+    preserves thin structures and small objects.
+
+    Example usage::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset(
+            "quickstart", max_samples=5, shuffle=True, seed=51
+        )
+
+        model = foz.load_zoo_model("moge-3-vitl-torch")
+
+        dataset.apply_model(model, label_field="depth")
+
+        session = fo.launch_app(dataset)
+
+    Args:
+        config: a :class:`MoGeModelConfig`
+    """
+
+    def _download_model(self, config):
+        if os.path.exists(config.name_or_path):
+            return
+
+        from huggingface_hub import hf_hub_download
+
+        hf_hub_download(repo_id=config.name_or_path, filename="model.pt")
+
+    def _load_model(self, config):
+        model = moge_v3.MoGeModel.from_pretrained(config.name_or_path)
+        model = model.to(self._device)
+        model.eval()
+        return model
+
+    @property
+    def media_type(self):
+        return "image"
+
+    def _forward_pass(self, imgs):
+        refine_steps = self.config.refine_steps
+        if refine_steps > 0 and self._device.type != "cuda":
+            logger.warning(
+                "MoGe-3 refinement needs a CUDA device; running without "
+                "refinement on %s",
+                self._device,
+            )
+            refine_steps = 0
+
+        depths, masks, normals, points, intrinsics = [], [], [], [], []
+        for img in imgs:
+            if isinstance(img, torch.Tensor):
+                tensor = img.to(self._device).float()
+                if tensor.ndim == 3 and tensor.shape[-1] in (3, 4):
+                    tensor = tensor[..., :3].permute(2, 0, 1)
+                if tensor.max() > 1.0:
+                    tensor = tensor / 255
+            else:
+                array = np.array(img)
+                if array.ndim == 2:
+                    array = np.stack([array] * 3, axis=-1)
+                elif array.shape[-1] == 4:
+                    array = array[..., :3]
+
+                tensor = (
+                    torch.from_numpy(np.ascontiguousarray(array))
+                    .to(self._device)
+                    .permute(2, 0, 1)
+                    .float()
+                    .div_(255)
+                )
+
+            output = self._model.infer(
+                tensor,
+                num_tokens=self.config.num_tokens,
+                resolution_level=self.config.resolution_level,
+                fov_x=self.config.fov_x,
+                refine_steps=refine_steps,
+                use_fp16=bool(
+                    self.config.use_fp16 or self.using_half_precision
+                ),
+            )
+
+            depths.append(output["depth"].detach().float().cpu().numpy())
+            mask = output.get("mask")
+            masks.append(
+                mask.detach().cpu().numpy() if mask is not None else None
+            )
+            k = output.get("intrinsics")
+            intrinsics.append(
+                k.detach().float().cpu().numpy() if k is not None else None
+            )
+            if (
+                self.config.include_normals
+                and output.get("normal") is not None
+            ):
+                normals.append(output["normal"].detach().float().cpu().numpy())
+            if self.config.include_points and output.get("points") is not None:
+                points.append(output["points"].detach().float().cpu().numpy())
+
+        result = {
+            "depth": depths,
+            "mask": masks,
+            "intrinsics": intrinsics,
+            "is_metric": True,
+        }
+        if normals:
+            result["normal"] = normals
+        if points:
+            result["points"] = points
+
+        return result

--- a/fiftyone/utils/moge.py
+++ b/fiftyone/utils/moge.py
@@ -37,8 +37,23 @@ moge_v3 = fou.lazy_import("moge.model.v3", callback=_ensure_moge)
 DEFAULT_MOGE_MODEL = "Ruicheng/moge-3-vitl"
 
 
+def _to_array(value):
+    """Converts one per-image output to a numpy array, keeping ``None``."""
+    if value is None:
+        return None
+
+    if isinstance(value, torch.Tensor):
+        return value.detach().float().cpu().numpy()
+
+    return np.asarray(value)
+
+
 def _to_arrays(value):
-    """Converts a batch of per-image outputs to a list of numpy arrays."""
+    """Converts a batch of per-image outputs to a list of numpy arrays.
+
+    Outputs the model did not produce for an image are kept as ``None`` so
+    that the list stays aligned with the batch.
+    """
     if value is None:
         return None
 
@@ -52,19 +67,33 @@ def _to_arrays(value):
             else list(value)
         )
 
-    return [
-        (
-            v.detach().float().cpu().numpy()
-            if isinstance(v, torch.Tensor)
-            else np.asarray(v)
-        )
-        for v in value
-    ]
+    return [_to_array(v) for v in value]
 
 
 def _is_single(value):
     """Whether an array holds one image's output rather than a batch."""
     return value.ndim == 2 or (value.ndim == 3 and value.shape[-1] in (1, 3))
+
+
+def _per_image(value, depths, name):
+    """Returns ``value`` when it holds one entry per image, else ``None``.
+
+    A shorter list cannot be attributed to particular images, so it is
+    dropped rather than applied to the wrong ones.
+    """
+    if value is None:
+        return None
+
+    if len(value) != len(depths):
+        logger.warning(
+            "Model output '%s' has %d entries for %d images; ignoring it",
+            name,
+            len(value),
+            len(depths),
+        )
+        return None
+
+    return value
 
 
 def _resize(array, size, nearest):
@@ -134,10 +163,12 @@ class MoGeOutputProcessor(fout.OutputProcessor):
         if not depths:
             raise ValueError("Model output 'depth' is empty")
 
-        masks = _to_arrays(output.get("mask"))
-        normals = _to_arrays(output.get("normal"))
-        points = _to_arrays(output.get("points"))
-        intrinsics = output.get("intrinsics")
+        masks = _per_image(_to_arrays(output.get("mask")), depths, "mask")
+        normals = _per_image(
+            _to_arrays(output.get("normal")), depths, "normal"
+        )
+        points = _per_image(_to_arrays(output.get("points")), depths, "points")
+        intrinsics = _per_image(output.get("intrinsics"), depths, "intrinsics")
         is_metric = output.get("is_metric", True)
 
         width, height = frame_size
@@ -165,11 +196,15 @@ class MoGeOutputProcessor(fout.OutputProcessor):
 
             if size is not None and depth.shape[:2] != (height, width):
                 depth = _resize(depth, size, nearest=False)
-                if mask is not None:
-                    mask = (
-                        _resize(mask.astype(np.float32), size, nearest=True)
-                        > 0.5
-                    )
+
+            if (
+                mask is not None
+                and size is not None
+                and mask.shape[:2] != (height, width)
+            ):
+                mask = (
+                    _resize(mask.astype(np.float32), size, nearest=True) > 0.5
+                )
 
             max_depth = float(np.max(depth)) if depth.size else 0.0
             if max_depth > 0:
@@ -186,20 +221,22 @@ class MoGeOutputProcessor(fout.OutputProcessor):
             if mask is not None:
                 heatmap.valid_mask = mask.astype(np.uint8)
 
-            if intrinsics is not None and i < len(intrinsics):
-                k = intrinsics[i]
+            k = intrinsics[i] if intrinsics and i < len(intrinsics) else None
+            if k is not None:
                 if isinstance(k, torch.Tensor):
                     k = k.detach().float().cpu().numpy()
                 heatmap.intrinsics = np.asarray(k, dtype=np.float32).tolist()
 
-            if normals is not None and i < len(normals):
-                normal = np.asarray(normals[i], dtype=np.float32)
+            normal = normals[i] if normals and i < len(normals) else None
+            if normal is not None:
+                normal = np.asarray(normal, dtype=np.float32)
                 if size is not None and normal.shape[:2] != (height, width):
                     normal = _resize(normal, size, nearest=False)
                 heatmap.normal_map = normal
 
-            if points is not None and i < len(points):
-                point_map = np.asarray(points[i], dtype=np.float32)
+            point_map = points[i] if points and i < len(points) else None
+            if point_map is not None:
+                point_map = np.asarray(point_map, dtype=np.float32)
                 if size is not None and point_map.shape[:2] != (height, width):
                     point_map = _resize(point_map, size, nearest=False)
                 heatmap.point_map = point_map
@@ -318,6 +355,15 @@ class MoGeModel(fout.TorchImageModel):
             )
             refine_steps = 0
 
+        use_fp16 = bool(self.config.use_fp16 or self.using_half_precision)
+        if use_fp16 and self._device.type != "cuda":
+            logger.warning(
+                "MoGe-3 half precision needs a CUDA device; running in full "
+                "precision on %s",
+                self._device,
+            )
+            use_fp16 = False
+
         depths, masks, normals, points, intrinsics = [], [], [], [], []
         for img in imgs:
             if isinstance(img, torch.Tensor):
@@ -347,9 +393,7 @@ class MoGeModel(fout.TorchImageModel):
                 resolution_level=self.config.resolution_level,
                 fov_x=self.config.fov_x,
                 refine_steps=refine_steps,
-                use_fp16=bool(
-                    self.config.use_fp16 or self.using_half_precision
-                ),
+                use_fp16=use_fp16,
             )
 
             depths.append(output["depth"].detach().float().cpu().numpy())
@@ -361,13 +405,10 @@ class MoGeModel(fout.TorchImageModel):
             intrinsics.append(
                 k.detach().float().cpu().numpy() if k is not None else None
             )
-            if (
-                self.config.include_normals
-                and output.get("normal") is not None
-            ):
-                normals.append(output["normal"].detach().float().cpu().numpy())
-            if self.config.include_points and output.get("points") is not None:
-                points.append(output["points"].detach().float().cpu().numpy())
+            if self.config.include_normals:
+                normals.append(_to_array(output.get("normal")))
+            if self.config.include_points:
+                points.append(_to_array(output.get("points")))
 
         result = {
             "depth": depths,
@@ -375,9 +416,9 @@ class MoGeModel(fout.TorchImageModel):
             "intrinsics": intrinsics,
             "is_metric": True,
         }
-        if normals:
+        if any(n is not None for n in normals):
             result["normal"] = normals
-        if points:
+        if any(p is not None for p in points):
             result["points"] = points
 
         return result

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3924,6 +3924,62 @@
             "date_added": "2026-02-03 12:00:00"
         },
         {
+            "base_name": "moge-3-vitl-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "MoGe-3 ViT-L (370M): metric monocular geometry from a single image, with depth, a camera-space point map, surface normals and camera intrinsics, refined by a sparse volumetric stage",
+            "source": "https://github.com/microsoft/MoGe",
+            "author": "Lingyu Kong, Ruicheng Li, Ruicheng Wang, et al.",
+            "license": "MIT",
+            "size_bytes": 1481333394,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.moge.MoGeModel",
+                "config": {
+                    "name_or_path": "Ruicheng/moge-3-vitl"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["depth", "3d", "torch", "transformer"],
+            "training_data": [],
+            "date_added": "2026-09-02 12:00:00"
+        },
+        {
+            "base_name": "moge-3-vitg-torch",
+            "base_filename": null,
+            "version": null,
+            "description": "MoGe-3 ViT-g (1.25B): the largest MoGe-3 model for metric monocular geometry, with depth, a camera-space point map, surface normals and camera intrinsics, refined by a sparse volumetric stage",
+            "source": "https://github.com/microsoft/MoGe",
+            "author": "Lingyu Kong, Ruicheng Li, Ruicheng Wang, et al.",
+            "license": "MIT",
+            "size_bytes": 5003249242,
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.moge.MoGeModel",
+                "config": {
+                    "name_or_path": "Ruicheng/moge-3-vitg"
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["depth", "3d", "torch", "transformer"],
+            "training_data": [],
+            "date_added": "2026-09-02 12:00:00"
+        },
+        {
             "base_name": "zero-shot-classification-transformer-torch",
             "base_filename": null,
             "version": null,

--- a/tests/unittests/utils/test_moge.py
+++ b/tests/unittests/utils/test_moge.py
@@ -1,0 +1,187 @@
+"""
+Tests for fiftyone/utils/moge.py MoGe-3 model wrapper.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import fiftyone.core.labels as fol
+
+
+class TestMoGeModelConfig:
+    """Test MoGeModelConfig parsing and defaults."""
+
+    def test_default_config(self):
+        from fiftyone.utils.moge import MoGeModelConfig
+
+        config = MoGeModelConfig({})
+
+        assert config.name_or_path == "Ruicheng/moge-3-vitl"
+        assert config.resolution_level == 9
+        assert config.num_tokens is None
+        assert config.refine_steps == 3
+        assert config.fov_x is None
+        assert config.use_fp16 is False
+        assert config.include_normals is False
+        assert config.include_points is False
+        assert config.raw_inputs is True
+        assert config.output_processor_cls == (
+            "fiftyone.utils.moge.MoGeOutputProcessor"
+        )
+
+    def test_custom_config(self):
+        from fiftyone.utils.moge import MoGeModelConfig
+
+        config = MoGeModelConfig(
+            {
+                "name_or_path": "Ruicheng/moge-3-vitg",
+                "resolution_level": 5,
+                "num_tokens": 2000,
+                "refine_steps": 0,
+                "fov_x": 60.0,
+                "use_fp16": True,
+                "include_normals": True,
+                "include_points": True,
+            }
+        )
+
+        assert config.name_or_path == "Ruicheng/moge-3-vitg"
+        assert config.resolution_level == 5
+        assert config.num_tokens == 2000
+        assert config.refine_steps == 0
+        assert config.fov_x == 60.0
+        assert config.use_fp16 is True
+        assert config.include_normals is True
+        assert config.include_points is True
+
+
+class TestMoGeOutputProcessor:
+    """Test MoGeOutputProcessor."""
+
+    def _make_processor(self):
+        from fiftyone.utils.moge import MoGeOutputProcessor
+
+        return MoGeOutputProcessor()
+
+    def test_invalid_output_type_raises(self):
+        processor = self._make_processor()
+
+        with pytest.raises(TypeError, match="Expected dict output"):
+            processor("not a dict", (2, 2))
+
+    def test_missing_depth_key_raises(self):
+        processor = self._make_processor()
+
+        with pytest.raises(KeyError, match="missing 'depth' key"):
+            processor({"mask": None}, (2, 2))
+
+    def test_depth_is_normalized_and_metric(self):
+        processor = self._make_processor()
+        depth = np.array([[10.0, 20.0], [30.0, 40.0]], dtype=np.float32)
+
+        results = processor({"depth": [depth]}, (2, 2))
+
+        assert len(results) == 1
+        heatmap = results[0]
+        assert isinstance(heatmap, fol.Heatmap)
+        assert heatmap.map.dtype == np.float32
+        assert heatmap.map.max() == pytest.approx(1.0)
+        assert heatmap.map[0, 0] == pytest.approx(0.25)
+        assert heatmap.is_metric is True
+        assert heatmap.max_depth == pytest.approx(40.0)
+        np.testing.assert_array_almost_equal(
+            heatmap.map * heatmap.max_depth, depth, decimal=5
+        )
+
+    def test_tensor_batch_is_split_per_image(self):
+        processor = self._make_processor()
+        depth = torch.tensor(
+            [[[1.0, 2.0], [3.0, 4.0]], [[0.0, 100.0], [100.0, 100.0]]]
+        )
+
+        results = processor({"depth": depth}, (2, 2))
+
+        assert len(results) == 2
+        assert results[0].max_depth == pytest.approx(4.0)
+        assert results[1].max_depth == pytest.approx(100.0)
+        assert results[1].map[0, 0] == pytest.approx(0.0)
+
+    def test_invalid_pixels_are_zeroed(self):
+        processor = self._make_processor()
+        depth = np.array([[np.inf, 2.0], [np.nan, 4.0]], dtype=np.float32)
+        mask = np.array([[0, 1], [0, 1]], dtype=bool)
+
+        results = processor({"depth": [depth], "mask": [mask]}, (2, 2))
+
+        heatmap = results[0]
+        assert heatmap.map[0, 0] == 0.0
+        assert heatmap.map[1, 0] == 0.0
+        assert heatmap.map[1, 1] == pytest.approx(1.0)
+        np.testing.assert_array_equal(
+            heatmap.valid_mask, np.array([[0, 1], [0, 1]], dtype=np.uint8)
+        )
+
+    def test_intrinsics_and_optional_maps_are_attached(self):
+        processor = self._make_processor()
+        depth = np.ones((2, 2), dtype=np.float32)
+        intrinsics = torch.tensor(
+            [[0.8, 0.0, 0.5], [0.0, 1.1, 0.5], [0.0, 0.0, 1.0]]
+        )
+        normal = np.zeros((2, 2, 3), dtype=np.float32)
+        normal[..., 2] = -1.0
+        points = np.ones((2, 2, 3), dtype=np.float32)
+
+        results = processor(
+            {
+                "depth": [depth],
+                "intrinsics": [intrinsics],
+                "normal": [normal],
+                "points": [points],
+            },
+            (2, 2),
+        )
+
+        heatmap = results[0]
+        assert heatmap.intrinsics[0][0] == pytest.approx(0.8)
+        assert len(heatmap.intrinsics) == 3
+        assert heatmap.normal_map.shape == (2, 2, 3)
+        assert heatmap.normal_map[0, 0, 2] == pytest.approx(-1.0)
+        assert heatmap.point_map.shape == (2, 2, 3)
+
+    def test_resize_to_frame_size(self):
+        processor = self._make_processor()
+        depth = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        mask = np.ones((2, 2), dtype=bool)
+        normal = np.zeros((2, 2, 3), dtype=np.float32)
+
+        results = processor(
+            {"depth": [depth], "mask": [mask], "normal": [normal]}, (4, 4)
+        )
+
+        heatmap = results[0]
+        assert heatmap.map.shape == (4, 4)
+        assert heatmap.valid_mask.shape == (4, 4)
+        assert heatmap.normal_map.shape == (4, 4, 3)
+        assert heatmap.map[0, 0] < heatmap.map[3, 3]
+
+    def test_none_frame_size_skips_resize(self):
+        processor = self._make_processor()
+        depth = np.random.rand(50, 60).astype(np.float32)
+
+        results = processor({"depth": [depth]}, (None, None))
+
+        assert results[0].map.shape == (50, 60)
+
+    def test_zero_depth_returns_zeros(self):
+        processor = self._make_processor()
+        depth = np.zeros((3, 3), dtype=np.float32)
+
+        results = processor({"depth": [depth]}, (3, 3))
+
+        assert np.all(results[0].map == 0)
+        assert results[0].max_depth == 0.0

--- a/tests/unittests/utils/test_moge.py
+++ b/tests/unittests/utils/test_moge.py
@@ -185,3 +185,55 @@ class TestMoGeOutputProcessor:
 
         assert np.all(results[0].map == 0)
         assert results[0].max_depth == 0.0
+
+    def test_none_mask_entry_is_skipped(self):
+        processor = self._make_processor()
+        depth = np.array([[10.0, 20.0], [30.0, 40.0]], dtype=np.float32)
+
+        results = processor({"depth": [depth], "mask": [None]}, (2, 2))
+
+        assert not hasattr(results[0], "valid_mask")
+        assert results[0].max_depth == pytest.approx(40.0)
+
+    def test_none_intrinsics_entry_is_skipped(self):
+        processor = self._make_processor()
+        depth = np.ones((2, 2), dtype=np.float32)
+
+        results = processor({"depth": [depth], "intrinsics": [None]}, (2, 2))
+
+        assert not hasattr(results[0], "intrinsics")
+
+    def test_mixed_none_entries_stay_aligned(self):
+        processor = self._make_processor()
+        depth = np.ones((2, 2), dtype=np.float32)
+        normal = np.zeros((2, 2, 3), dtype=np.float32)
+        normal[..., 2] = -1.0
+
+        results = processor(
+            {"depth": [depth, depth], "normal": [None, normal]}, (2, 2)
+        )
+
+        assert not hasattr(results[0], "normal_map")
+        assert results[1].normal_map[0, 0, 2] == pytest.approx(-1.0)
+
+    def test_short_optional_list_is_ignored(self):
+        processor = self._make_processor()
+        depth = np.ones((2, 2), dtype=np.float32)
+        normal = np.zeros((2, 2, 3), dtype=np.float32)
+
+        results = processor(
+            {"depth": [depth, depth], "normal": [normal]}, (2, 2)
+        )
+
+        assert not hasattr(results[0], "normal_map")
+        assert not hasattr(results[1], "normal_map")
+
+    def test_mask_is_resized_when_depth_already_matches(self):
+        processor = self._make_processor()
+        depth = np.ones((4, 4), dtype=np.float32)
+        mask = np.ones((2, 2), dtype=bool)
+
+        results = processor({"depth": [depth], "mask": [mask]}, (4, 4))
+
+        assert results[0].map.shape == (4, 4)
+        assert results[0].valid_mask.shape == (4, 4)


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

Adds MoGe-3 (https://github.com/microsoft/MoGe) to the model zoo as
`moge-3-vitl-torch` (370M) and `moge-3-vitg-torch` (1.25B), both MIT.

MoGe-3 predicts metric monocular geometry from a single image.
`fiftyone.utils.moge.MoGeModel` returns a `Heatmap` whose `map` is the depth
normalized by its maximum, with `max_depth` in metres, `is_metric`, the
predicted valid-pixel mask as `valid_mask` and the normalized camera
intrinsics as `intrinsics`. `include_normals` and `include_points` attach the
surface normal map and the camera-space point map. `resolution_level`,
`num_tokens`, `refine_steps`, `fov_x` and `use_fp16` map to the model's
inference options. The `moge` package installs on first use, pinned to a
commit. Sparse refinement runs on CUDA; on CPU the wrapper skips it and logs
a warning.

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5)
model = foz.load_zoo_model("moge-3-vitl-torch")
dataset.apply_model(model, label_field="depth")
```

## 🧪 How is this patch tested? If it is not, please explain why.

- `tests/unittests/utils/test_moge.py` covers config parsing and the output
  processor: normalization, metric recovery, invalid-pixel masking, attached
  intrinsics, normals and points, resizing to the frame size, and edge cases.
- Ran `moge-3-vitl-torch` on an RTX 6000 Ada through `predict()` and
  `apply_model()`: 437x640 heatmaps, 2.6 GB peak VRAM, and every attribute
  survives the MongoDB round trip. Also ran `refine_steps=0` with
  `include_normals` and `include_points`.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Added MoGe-3 (`moge-3-vitl-torch`, `moge-3-vitg-torch`) to the
      model zoo: metric monocular depth with surface normals, point maps and
      camera intrinsics.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3980
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the MoGe-3 depth-estimation model.
  * Supports Hugging Face and local model checkpoints.
  * Provides metric depth maps, masks, camera intrinsics, and optional surface normals and point maps.
  * Includes configurable refinement, field of view, precision, and output resolution settings.
  * Supports tensor, grayscale, RGB, RGBA, and array image inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->