### PR TITLE
Serialize untyped info dict values properly

### DIFF
--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -1179,6 +1179,24 @@ class DictField(mongoengine.fields.DictField, Field):
             for _value in value.values():
                 self.field.validate(_value)
 
+    def to_mongo(self, value, use_db_field=True, fields=None):
+        # Untyped dict values bypass each subfield's own `to_mongo()`, so
+        # they aren't otherwise serialized to BSON-safe types (dates, numpy
+        # arrays, etc). `serialize_value()` already recursively handles
+        # this, so we return its result directly rather than also
+        # delegating to `super().to_mongo()`, which would recurse back into
+        # this same method for each already-serialized value (eg treating
+        # an already-serialized `Binary` as an iterable of raw bytes)
+        if self.field is None and isinstance(value, dict):
+            # Imported here to avoid a circular import with `fiftyone.core.odm`
+            import fiftyone.core.odm.utils as foou
+
+            return foou.serialize_value(value, extended=False)
+
+        return super().to_mongo(
+            value, use_db_field=use_db_field, fields=fields
+        )
+
 
 class MediaReferenceField(Field):
     """The protected immutable media-reference descriptor field.

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -475,6 +475,56 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(field.info, {"foo2": "bar2"})
 
     @drop_datasets
+    def test_dataset_field_info_serialization(self):
+        # https://github.com/voxel51/fiftyone/issues/2865
+        #
+        # Untyped `info` dicts must serialize the same value types that are
+        # natively supported by typed fields (dates, numpy arrays, etc),
+        # since untyped dict values otherwise bypass each subfield's own
+        # `to_mongo()`
+        dataset = fo.Dataset()
+
+        today = date.today()
+        arr = np.array([1.0, 2.0, 3.0])
+
+        dataset.add_sample_field(
+            "field1",
+            fo.DateField,
+            info={
+                "date": today,
+                "nested": {"date": today},
+                "list": [today],
+                "arr": arr,
+                "flag": True,
+                "n": 5,
+            },
+        )
+
+        field = dataset.get_field("field1")
+        self.assertEqual(field.info["date"], today)
+        self.assertEqual(field.info["nested"]["date"], today)
+        self.assertEqual(field.info["list"], [today])
+        self.assertTrue(np.array_equal(field.info["arr"], arr))
+        self.assertEqual(field.info["flag"], True)
+        self.assertEqual(field.info["n"], 5)
+
+        dataset.reload()
+
+        # `date` values necessarily round-trip as UTC midnight `datetime`
+        # values, since BSON has no native date-only type
+        field = dataset.get_field("field1")
+        self.assertEqual(
+            field.info["date"], datetime(today.year, today.month, today.day)
+        )
+
+        # The array must round-trip with its values intact, not be mangled
+        # into a list of raw serialized bytes (a regression risk of
+        # `DictField.to_mongo()` delegating to `super().to_mongo()`, which
+        # would recurse back into itself and treat the already-serialized
+        # `Binary` value as an iterable of raw bytes)
+        self.assertTrue(np.array_equal(field.info["arr"], arr))
+
+    @drop_datasets
     def test_dataset_shared_field_metadata(self):
         """Test field metadata for default/shared fields"""
         dataset1 = fo.Dataset()


### PR DESCRIPTION
Fixes #2865

Updated per review: the root cause isn't `date`-specific, it's that untyped
`DictField` values bypass each subfield's own `to_mongo()` entirely, so
*any* type that isn't natively BSON-encodable breaks the same way. Switched
to reusing the existing `serialize_value()` utility
(`fiftyone/core/odm/utils.py`), which already handles this generally.

```py
dataset.add_sample_field("example", fo.DateField, info={"date": date.today()})
# pymongo.errors.InvalidDocument: cannot encode object: datetime.date(...), of type: <class 'datetime.date'>
```

## Fix

`DictField.to_mongo()` now delegates to `serialize_value(value, extended=False)`
for untyped dict values, which recursively converts dates, numpy arrays,
bools, ObjectIds, etc. through nested dicts/lists — the same logic already
relied on elsewhere in the codebase, rather than a narrower hand-rolled
`date`-only conversion.

**One thing I had to get right along the way:** the serialized result must be
returned directly, *not* also passed through `super().to_mongo()`. That
generic mongoengine path recurses back into `to_mongo()` for each
already-serialized value — and for a numpy array, `serialize_value()`
produces a `bson.Binary`, which mongoengine's generic fallback (seeing no
`.items()`) treats as an iterable and explodes into a list of raw bytes.
I caught this by testing beyond the reported repro (numpy arrays weren't
in the original issue, but are handled by the same code path) — first pass
of this fix actually corrupted numpy array values in `info` dicts silently.
Fixed by short-circuiting and returning `serialize_value()`'s result
directly for the untyped-dict case.

This applies to any untyped `DictField` in FiftyOne (e.g. `dataset.info`
benefits too), not just field `info`, since it's the same field class.

Note: since BSON has no native date-only type, `date` values still
round-trip as `datetime` at UTC midnight — the same tradeoff `fo.DateField`
itself resolves via `to_python()` for typed fields.

## Testing

- Reproduced the original crash and root-caused it to untyped
  `ComplexBaseField.to_mongo()`'s recursion in mongoengine.
- Caught the `Binary`-corruption regression myself by testing numpy arrays
  in `info` dicts (not part of the original report) — confirmed via a raw
  `to_mongo()` unit call and a full save + fresh-process reload showing
  byte-exploded garbage before the fix, correct values after.
- Expanded `test_dataset_field_info_date` → `test_dataset_field_info_serialization`
  in `tests/unittests/dataset_tests.py` to cover dates, nested dicts/lists,
  numpy arrays, bools, and ints, plus a full save+reload round trip with an
  explicit regression check against the byte-explosion corruption.
- Ran `dataset_tests.py` + `label_tests.py` + `odm_tests.py` (167 tests)
  locally against a real MongoDB instance — all passing (one pre-existing,
  unrelated timing-based flaky test, confirmed passing in isolation).
- black/pylint clean.
