### PR TITLE
Fix iter_slices() hang/silent data loss on non-positive batch_size

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -2654,12 +2654,19 @@ def iter_slices(sliceable, batch_size):
         from the input
 
     Raises:
-        ValueError: if a dict-like ``sliceable`` has values with mismatched
+        ValueError: if ``batch_size`` is not a positive integer or ``None``,
+            or if a dict-like ``sliceable`` has values with mismatched
             lengths
     """
     if batch_size is None:
         yield sliceable
         return
+
+    if not isinstance(batch_size, numbers.Integral) or batch_size < 1:
+        raise ValueError(
+            "batch_size must be a positive integer or None; found %r"
+            % (batch_size,)
+        )
 
     if isinstance(sliceable, Mapping):
         # dict-like batches (eg HuggingFace ``BatchFeature``) are sliced

--- a/tests/unittests/utils/test_torch_patches.py
+++ b/tests/unittests/utils/test_torch_patches.py
@@ -68,6 +68,15 @@ class TestIterSlicesMapping:
         with pytest.raises(ValueError, match="mismatched lengths"):
             list(fou.iter_slices(batch, 2))
 
+    @pytest.mark.parametrize("batch_size", [0, -1, -5])
+    def test_mapping_non_positive_batch_size_raises(self, batch_size):
+        # Previously: batch_size=0 raised a confusing internal
+        # `range() arg 3 must not be zero`, and a negative batch_size
+        # silently dropped all data (0 batches, no error)
+        batch = {"a": torch.zeros(3, 1)}
+        with pytest.raises(ValueError, match="positive integer"):
+            list(fou.iter_slices(batch, batch_size))
+
     def test_numpy_mapping_patches_merged(self):
         patches = [
             {"pixel_values": np.zeros((1, 4, 4, 3))},
@@ -75,3 +84,22 @@ class TestIterSlicesMapping:
         ]
         out = fout._stack_transformed_patches(patches, use_numpy=True)
         assert out["pixel_values"].shape == (2, 4, 4, 3)
+
+
+class TestIterSlicesSequence:
+    def test_sequence_sliced(self):
+        chunks = list(fou.iter_slices([1, 2, 3, 4, 5], 2))
+        assert chunks == [[1, 2], [3, 4], [5]]
+
+    def test_sequence_none_batch_size_passthrough(self):
+        data = [1, 2, 3]
+        chunks = list(fou.iter_slices(data, None))
+        assert len(chunks) == 1
+        assert chunks[0] is data
+
+    @pytest.mark.parametrize("batch_size", [0, -1, -5])
+    def test_sequence_non_positive_batch_size_raises(self, batch_size):
+        # Previously: batch_size<=0 caused an infinite loop (`start` never
+        # advanced), hanging the caller forever with no error
+        with pytest.raises(ValueError, match="positive integer"):
+            list(fou.iter_slices([1, 2, 3], batch_size))


### PR DESCRIPTION
Not tied to a filed issue — found this myself while auditing `fou.iter_slices()`
(the recently-added batching helper backing `Model.compute_patch_embeddings()`,
`SampleCollection.map_samples()`/`update_samples()`, and the Beam pipeline
batching in `fiftyone/utils/beam.py`) after working on a couple of other fixes
in this codebase.

## The bug

`iter_slices(sliceable, batch_size)` never validated `batch_size`, and a
non-positive value broke in three different, silent ways depending on the
input shape:

```py
import fiftyone.core.utils as fou

# 1. plain sequences: hangs forever once fully consumed -- `start` never
#    advances since `start += batch_size` is a no-op at 0
list(fou.iter_slices([1, 2, 3], 0))          # hangs, no error, no progress

# 2. dict-like batches (eg HuggingFace `BatchFeature`): batch_size == 0
#    leaks a confusing internal error from deep in the generator
list(fou.iter_slices({"a": [1, 2, 3]}, 0))
# ValueError: range() arg 3 must not be zero

# 3. dict-like batches: batch_size < 0 produces an empty range --
#    silently returns zero batches, dropping ALL the data with no error
list(fou.iter_slices({"a": [1, 2, 3]}, -1))  # -> [] (!)
```

This is reachable through public, documented `batch_size` kwargs that don't
validate positivity before passing through — eg `_parse_batch_size()` in
`fiftyone/core/models.py` accepts any non-`None` value unchanged, so
`model.compute_patch_embeddings(dataset, patches_field, batch_size=0)` would
hang the process indefinitely with zero feedback. A typo (`0` instead of
`None`) or a programmatically-computed batch size that lands on `0`/negative
is a realistic way to hit this, and the silent-data-loss variant (#3) is
worse than a crash since nothing indicates anything went wrong.

## Fix

`iter_slices()` now raises a clear `ValueError` immediately for any
`batch_size` that isn't a positive integer or `None`, closing all three
failure modes at the single shared choke point rather than requiring every
call site to validate separately.

## Testing

- Reproduced all three failure modes directly (hang confirmed via a
  `signal.alarm` timeout, since it genuinely never returns).
- Added `test_sequence_non_positive_batch_size_raises` and
  `test_mapping_non_positive_batch_size_raises` (parametrized over
  `0, -1, -5`) to `tests/unittests/utils/test_torch_patches.py`, plus a new
  `TestIterSlicesSequence` class covering normal usage for the plain-sequence
  branch, which previously had zero test coverage at all.
- Ran the full test file (15 tests) plus `dataset_tests.py` +
  `utils_tests.py` + the rest of `tests/unittests/utils/` (449 tests total)
  locally — all passing, confirmed no regression to normal batching
  behavior for either branch.
- black/pylint clean.
