### PR TITLE
One voodo, enforced

### DIFF
--- a/.github/workflows/lint-app.yml
+++ b/.github/workflows/lint-app.yml
@@ -35,6 +35,10 @@ jobs:
 
       - name: Install Dependencies
         run: cd app && yarn install
+      - name: Check constraints
+        # app/yarn.config.cjs: singleton dependencies (the design system) are
+        # declared through the yarn catalog only
+        run: cd app && yarn constraints
 
       - parallel:
           - name: Lint ESLint packages

--- a/app/package.json
+++ b/app/package.json
@@ -84,7 +84,6 @@
     "resolutions": {
         "@types/mapbox-gl": "2.7.21",
         "@types/react": "18.3.12",
-        "@voxel51/voodo": "^0.1.0",
         "brace-expansion": "^5.0.6",
         "minimatch": "9.0.7",
         "prettier": "~3.8.4",

--- a/app/packages/embeddings-v2/package.json
+++ b/app/packages/embeddings-v2/package.json
@@ -32,7 +32,7 @@
         "@testing-library/dom": "catalog:",
         "@testing-library/react": "catalog:",
         "@types/react": "catalog:",
-        "@types/react-dom": "^18.3.1",
+        "@types/react-dom": "catalog:",
         "@types/three": "^0.182.0",
         "jotai": "catalog:",
         "react": "catalog:",

--- a/app/yarn.config.cjs
+++ b/app/yarn.config.cjs
@@ -1,0 +1,40 @@
+// Yarn constraints (`yarn constraints`; `yarn constraints --fix` rewrites
+// manifests). Enforced in CI by lint-app.yml.
+//
+// Some dependencies must exist exactly once in the bundle. The design system
+// carries React context and CSS: two copies means two contexts and two
+// stylesheets, and when the catalog moves, a stray range leaves the merged
+// lockfile unable to satisfy it — downstream image builds then fail at
+// install with no readable error. So a singleton's version lives in ONE place,
+// the yarn catalog in .yarnrc.yml, and every workspace defers to it with
+// `catalog:`. Peer dependencies are exempt: the catalog protocol is not valid
+// there. The same rule runs downstream over the enterprise app's own
+// workspaces (.github/scripts/catalog-drift.mjs there).
+
+/** Dependencies that must resolve to one version across the monorepo. */
+const SINGLETONS = ["@voxel51/voodo"];
+
+/** `catalog:` and the named form `catalog:<group>` both defer to the catalog. */
+const isCatalogRange = (range) => range.startsWith("catalog:");
+
+module.exports = {
+  async constraints({ Yarn }) {
+    for (const ident of SINGLETONS) {
+      for (const dependency of Yarn.dependencies({ ident })) {
+        if (dependency.type === "peerDependencies") {
+          continue;
+        }
+        if (!isCatalogRange(dependency.range)) {
+          // `--fix` rewrites it; without `--fix` this reports the mismatch
+          dependency.update("catalog:");
+        }
+      }
+
+      for (const workspace of Yarn.workspaces()) {
+        if (workspace.manifest.resolutions?.[ident] !== undefined) {
+          workspace.unset(["resolutions", ident]);
+        }
+      }
+    }
+  },
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1856,7 +1856,7 @@ __metadata:
     "@testing-library/dom": "catalog:"
     "@testing-library/react": "catalog:"
     "@types/react": "catalog:"
-    "@types/react-dom": "npm:^18.3.1"
+    "@types/react-dom": "catalog:"
     "@types/three": "npm:^0.182.0"
     "@voxel51/voodo": "catalog:"
     jotai: "catalog:"


### PR DESCRIPTION
Some dependencies must exist exactly once in the App bundle. The design system is the clear case: two copies means two React contexts and two stylesheets, and when the yarn catalog moves, a workspace still pinning its own range leaves downstream lockfiles unable to satisfy it — the enterprise image build then fails at install with no readable error. That happened today when #8120 moved the catalog to a voodo prerelease; the enterprise side had three such pins plus a `resolutions` entry (fixed and guarded in voxel51/fiftyone-teams#3985).

This is the OSS half of the guard, so the pin is caught where it is introduced:

- `app/yarn.config.cjs`: a Yarn constraint. Singleton dependencies (`@voxel51/voodo` today; the list takes more names) must be `catalog:` — the named form `catalog:<group>` counts — in every workspace, and may not appear under `resolutions`. Peer dependencies are exempt, since the catalog protocol is not valid there. `yarn constraints --fix` rewrites offenders.
- `lint-app.yml` runs `yarn constraints` after install.
- The one existing violation, the `resolutions` pin beside the catalog in `app/package.json`, is removed. The lockfile does not change: the pin matched the catalog.

Because `app/` syncs to the enterprise repo, the constraints file travels with it and both repos enforce the rule at the source. The enterprise script stays as the cross-project check for `teams-app`, which OSS never sees.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3988
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated dependency consistency checks to the application workflow.
  - Enforced catalog-based configuration for the shared `@voxel51/voodo` dependency.
  - Ensured the application uses a single version of the shared dependency.
  - Standardized eligible dependency ranges while excluding peer dependencies from validation.
  - Removed redundant workspace resolution entries where catalog-managed dependencies apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->