### PR TITLE
Multimodal: tile media-surface and ruler-overlay seams for external overlays

### DIFF
--- a/app/packages/multimodal/src/extensions/README.md
+++ b/app/packages/multimodal/src/extensions/README.md
@@ -19,6 +19,13 @@ below its tab shell. A tray takes no props: whether a surface hosts trays at
 all is decided where that surface builds its sidebar, so a tray never has to
 interpret facts about where it ended up.
 
+The tile media-surface seam (`tiles/media-surfaces.ts`) publishes where each
+2D-media tile draws its stream, plus the episode's open-tile/seek/pause
+commands. Only views publish; a product entrypoint reads it to overlay a tile's
+media or to send the episode back to a stream and a moment. A timeline
+contribution may also supply a `rulerOverlay`, rendered over the episode ruler
+at the ruler's live label width.
+
 A registry may opt into a `replace` duplicate-id policy when its registration
 module is evaluated by a bundler that gives it no disposal hook. Ordering stays
 `order`-driven regardless, so replacement never changes placement.

--- a/app/packages/multimodal/src/extensions/tiles/index.ts
+++ b/app/packages/multimodal/src/extensions/tiles/index.ts
@@ -1,3 +1,10 @@
+export { useTileMediaEpisode, useTileMediaSurfaces } from "./media-surfaces";
+export type {
+  TileMediaEpisode,
+  TileMediaRect,
+  TileMediaSurface,
+  TileMediaSurfaceSource,
+} from "./media-surfaces";
 export { registerEpisodeTileExtension } from "./registry";
 export { useEpisodeTileExtensionSettings } from "./settings";
 export type {

--- a/app/packages/multimodal/src/extensions/tiles/media-surfaces.ts
+++ b/app/packages/multimodal/src/extensions/tiles/media-surfaces.ts
@@ -47,7 +47,7 @@ export const tileMediaSurfacesAtom = atom<
   Readonly<Record<string, TileMediaSurface>>
 >({});
 
-/** Every mounted 2D-media tile surface, in registration order. */
+/** Every mounted 2D-media tile surface. */
 export function useTileMediaSurfaces(): readonly TileMediaSurface[] {
   const surfaces = useAtomValue(tileMediaSurfacesAtom);
   return useMemo(() => Object.values(surfaces), [surfaces]);

--- a/app/packages/multimodal/src/extensions/tiles/media-surfaces.ts
+++ b/app/packages/multimodal/src/extensions/tiles/media-surfaces.ts
@@ -1,0 +1,83 @@
+import { atom, useAtomValue } from "jotai";
+import { useMemo } from "react";
+
+/**
+ * Where each 2D-media tile draws its stream, and the episode's media
+ * commands — published by the view layer, read by features hosted outside
+ * this package that overlay a tile's media or send the episode back to a
+ * stream and a moment. Open source publishes and reads nothing back.
+ *
+ * Entries live in the tiling shell's per-instance jotai store, so they are
+ * scoped to one episode modal and vanish with it; a consumer outside any
+ * episode modal reads an empty registry and a null episode.
+ */
+
+/** Stable, recording-independent identity of a displayed stream. */
+export type TileMediaSurfaceSource = {
+  /** Semantic family, e.g. `"image"`. */
+  type: string;
+  /** Format-native stream name, e.g. `"CAM_FRONT"`. */
+  name: string;
+};
+
+/** Where a tile currently draws its media, in element-local CSS pixels. */
+export type TileMediaRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export type TileMediaSurface = {
+  tileId: string;
+  source: TileMediaSurfaceSource;
+  /** The tile's media viewport element — overlays portal into it. */
+  element: HTMLElement;
+  /**
+   * Displayed-media rect in element-local px, or null before the media has
+   * loaded. Reads live layout — safe to call once per animation frame.
+   */
+  getMediaRect: () => TileMediaRect | null;
+  /** Absolute content time (integer ns) of the displayed frame, or null. */
+  getContentTimeNs: () => bigint | null;
+};
+
+/** Internal — published by `useRegisterTileMediaSurface` (views). */
+export const tileMediaSurfacesAtom = atom<
+  Readonly<Record<string, TileMediaSurface>>
+>({});
+
+/** Every mounted 2D-media tile surface, in registration order. */
+export function useTileMediaSurfaces(): readonly TileMediaSurface[] {
+  const surfaces = useAtomValue(tileMediaSurfacesAtom);
+  return useMemo(() => Object.values(surfaces), [surfaces]);
+}
+
+/**
+ * Episode-level media commands. Unlike the per-tile registry these work for
+ * streams whose tile is currently closed — e.g. reopening the tile a
+ * persisted reference points at.
+ */
+export type TileMediaEpisode = {
+  /** Focus the tile showing the stream, or open one; no-op if unknown. */
+  openTileForSource: (source: TileMediaSurfaceSource) => void;
+  /** Pause playback and move the playhead to an absolute content time. */
+  seekToTimeNs: (timeNs: bigint) => void;
+  /**
+   * Timeline seconds a seek to this content time lands on, or null before
+   * the timeline index exists — the number the playhead readout will show,
+   * so labels formatted with it match what clicking them produces.
+   */
+  secondsForTimestamp: (timeNs: bigint) => number | null;
+  pause: () => void;
+};
+
+/** Internal — published by `TileMediaEpisodePublisher` (views). */
+export const tileMediaEpisodeAtom = atom<TileMediaEpisode | null>(
+  null as TileMediaEpisode | null,
+);
+
+/** The mounted episode's media commands, or null outside an episode modal. */
+export function useTileMediaEpisode(): TileMediaEpisode | null {
+  return useAtomValue(tileMediaEpisodeAtom);
+}

--- a/app/packages/multimodal/src/extensions/timeline/host.tsx
+++ b/app/packages/multimodal/src/extensions/timeline/host.tsx
@@ -142,6 +142,27 @@ const ComposedTimeline: React.FC<{
       {contribution.value.runtime}
     </Fragment>
   ));
+  const rulerOverlay = useMemo(() => {
+    const overlays = contributions.flatMap((contribution) =>
+      contribution.value.rulerOverlay
+        ? [
+            {
+              id: contribution.extensionId,
+              render: contribution.value.rulerOverlay,
+            },
+          ]
+        : [],
+    );
+    return overlays.length === 0
+      ? undefined
+      : (labelWidth: number) => (
+          <>
+            {overlays.map((overlay) => (
+              <Fragment key={overlay.id}>{overlay.render(labelWidth)}</Fragment>
+            ))}
+          </>
+        );
+  }, [contributions]);
 
   return (
     <>
@@ -149,6 +170,7 @@ const ComposedTimeline: React.FC<{
         decorateTrack,
         onDrawerOpenChange,
         preferences,
+        rulerOverlay,
         runtime,
         tracks,
       })}

--- a/app/packages/multimodal/src/extensions/timeline/types.ts
+++ b/app/packages/multimodal/src/extensions/timeline/types.ts
@@ -37,6 +37,8 @@ export interface TimelineContribution {
   readonly sections?: readonly TimelineSection[];
   /** Runs inside the playback, track, tiling, and episode data-stream providers. */
   readonly runtime?: React.ReactNode;
+  /** Rendered over the timeline ruler, given the ruler's effective label width. */
+  readonly rulerOverlay?: (labelWidth: number) => React.ReactNode;
   readonly preferences?: TimelinePreferences;
   readonly onDrawerOpenChange?: (open: boolean) => void;
 }
@@ -68,6 +70,7 @@ export interface TimelineComposition {
   readonly decorateTrack: TimelineTrackDecorator;
   readonly onDrawerOpenChange?: (open: boolean) => void;
   readonly preferences: TimelinePreferences;
+  readonly rulerOverlay?: (labelWidth: number) => React.ReactNode;
   readonly runtime: React.ReactNode;
   readonly tracks: readonly Track[];
 }

--- a/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
+++ b/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
@@ -56,6 +56,7 @@ import {
   usePreferredImageTileStream,
   usePublishImageTileBinding,
 } from "../tiles/tile-source-bindings";
+import { useRegisterTileMediaSurface } from "../tiles/tile-media-surfaces";
 import ImageAnnotationOverlay from "./ImageAnnotationOverlay";
 import DepthHoverOverlay from "./DepthHoverOverlay";
 import ImageProjectionOverlay from "./ImageProjectionOverlay";
@@ -610,6 +611,26 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
     imageSize: effectiveImageDims,
     resetKey: `${stream}\n${cameraProjection.display}\n${rectifiedViewActive}`,
   });
+  // The pan/zoom hook keeps the surface element to itself; tee its ref so
+  // the media-surface registry (external overlays) can portal into it.
+  const [mediaSurfaceElement, setMediaSurfaceElement] =
+    useState<HTMLDivElement | null>(null);
+  const { surfaceRef: panZoomSurfaceRef } = imagePanZoom;
+  const mediaSurfaceRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      panZoomSurfaceRef(element);
+      setMediaSurfaceElement(element);
+    },
+    [panZoomSurfaceRef],
+  );
+  useRegisterTileMediaSurface({
+    element: mediaSurfaceElement,
+    source: selectedImageSource,
+    imageSize: effectiveImageDims,
+    fit: IMAGE_FIT,
+    viewTransform: imagePanZoom.viewTransform,
+    contentTimeNs: playbackFrame?.contentTimeNs ?? null,
+  });
   const toggleLabelStream = useCallback(
     (labelStream: string, checked: boolean) => {
       if (!stream) return;
@@ -923,7 +944,7 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
           onPointerDown={imagePanZoom.onPointerDown}
           onPointerMove={imagePanZoom.onPointerMove}
           onPointerUp={imagePanZoom.onPointerUp}
-          ref={imagePanZoom.surfaceRef}
+          ref={mediaSurfaceRef}
           style={imagePanZoom.surfaceStyle}
         >
           {frame && playbackFrame ? (

--- a/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
+++ b/app/packages/multimodal/src/views/episode/image/ImageTile.tsx
@@ -629,7 +629,9 @@ const ImageTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
     imageSize: effectiveImageDims,
     fit: IMAGE_FIT,
     viewTransform: imagePanZoom.viewTransform,
-    contentTimeNs: playbackFrame?.contentTimeNs ?? null,
+    // The committed frame, not the requested one: decoding keeps the previous
+    // pixels visible, and an overlay must target what is actually on screen.
+    contentTimeNs: committedImageContentTimeNs,
   });
   const toggleLabelStream = useCallback(
     (labelStream: string, checked: boolean) => {

--- a/app/packages/multimodal/src/views/episode/playback/content-time-seek.ts
+++ b/app/packages/multimodal/src/views/episode/playback/content-time-seek.ts
@@ -1,0 +1,17 @@
+import type { TimelineIndex } from "../../../runtime/timeline-index";
+
+/**
+ * The playhead seconds that make the content frame at `timeNs` the one
+ * presented. Everything downstream of the playhead quantizes to the
+ * timeline's tick grid via nearest-tick rounding, so seeking to a content
+ * time's raw seconds can land on the tick BEFORE it, and at-or-before
+ * sampling then misses the very frame the time came from. Seek to the first
+ * tick at-or-after the content time instead.
+ */
+export function timelineSecondsForContentTimeNs(
+  index: TimelineIndex,
+  timeNs: bigint,
+): number {
+  const tick = index.tickAt(index.indexAtOrAfter(timeNs));
+  return index.nsToSec(tick ?? timeNs);
+}

--- a/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/ModalRenderer.tsx
@@ -78,12 +78,14 @@ const ModalRenderer: React.FC<SampleRendererProps> = ({ ctx }) => {
           decorateTrack,
           onDrawerOpenChange,
           preferences,
+          rulerOverlay,
           runtime,
           tracks,
         }) => (
           <SourcePlayback
             defaultPinnedTrackIds={defaultPinnedTrackIds}
             decorateTrack={decorateTrack}
+            timelineRulerOverlay={rulerOverlay}
             episodeContext={{ datasetId, sampleId }}
             fileName={fileName}
             initialSeekTimeNs={firstMatch?.startNs ?? null}

--- a/app/packages/multimodal/src/views/episode/shell/PlaybackShell.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/PlaybackShell.tsx
@@ -31,6 +31,7 @@ import {
 import { SceneInventoryProvider } from "../../../scene-inventory/react/index";
 import type { SceneSource } from "../../../scene-inventory/index";
 import { WebGpuViewStage } from "../../../visualization/webgpu/WebGpuViewStage";
+import { TileMediaEpisodePublisher } from "../tiles/TileMediaEpisodePublisher";
 import styles from "./PlaybackShell.module.css";
 
 const EMPTY_SOURCES: readonly SceneSource[] = [];
@@ -93,6 +94,8 @@ export interface PlaybackShellProps {
   defaultPinnedTrackIds?: string[];
   /** Per-row behavior composed from shared and registered timeline sources. */
   decorateTrack?: TemporalTagTimelineProps["decorateTrack"];
+  /** Ruler overlay composed from registered timeline sources. */
+  timelineRulerOverlay?: (labelWidth: number) => React.ReactNode;
 
   /** Initial tile entries seeded into the embedded TilingProvider. */
   initialTiles?: Record<string, TilingTile>;
@@ -256,6 +259,7 @@ const PlaybackShell: React.FC<PlaybackShellProps> = ({
   tracks,
   defaultPinnedTrackIds,
   decorateTrack,
+  timelineRulerOverlay,
   initialTiles,
   initialManualTileTitles,
   autoLayoutStrategy,
@@ -310,6 +314,7 @@ const PlaybackShell: React.FC<PlaybackShellProps> = ({
             resetLayoutStrategy={resetLayoutStrategy}
           >
             {children}
+            <TileMediaEpisodePublisher />
             <Layout
               fileName={fileName}
               headerCaption={headerCaption}
@@ -342,6 +347,7 @@ const PlaybackShell: React.FC<PlaybackShellProps> = ({
               // visible below the ruler until the user expands the drawer.
               timelineDrawerDefaultOpen={false}
               decorateTrack={decorateTrack}
+              timelineRulerOverlay={timelineRulerOverlay}
             />
           </TilingProvider>
         </SceneInventoryProvider>
@@ -384,6 +390,7 @@ interface LayoutProps {
   /** Initial open state for the timeline drawer. */
   timelineDrawerDefaultOpen: boolean;
   decorateTrack?: PlaybackShellProps["decorateTrack"];
+  timelineRulerOverlay?: PlaybackShellProps["timelineRulerOverlay"];
 }
 
 function Layout({
@@ -414,6 +421,7 @@ function Layout({
   className,
   timelineDrawerDefaultOpen,
   decorateTrack,
+  timelineRulerOverlay,
 }: LayoutProps) {
   const {
     layout,
@@ -625,6 +633,7 @@ function Layout({
         onDrawerOpenChange={updateTimelineTracksOpen}
         trailingActions={timelineTrailingActions}
         decorateTrack={decorateTrack}
+        rulerOverlay={timelineRulerOverlay}
         readouts={timelineReadouts}
         extraActions={timelineExtraActions}
         existingTags={existingTags}

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -140,6 +140,8 @@ export interface SourcePlaybackProps {
   readonly defaultPinnedTrackIds?: readonly string[];
   /** Per-row timeline decoration contributed by timeline sources. */
   readonly decorateTrack?: TemporalTagTimelineProps["decorateTrack"];
+  /** Ruler overlay composed from timeline sources. */
+  readonly timelineRulerOverlay?: (labelWidth: number) => React.ReactNode;
   readonly fileName: string;
   /** Present only for the dataset sample modal, never the Explorer. */
   readonly episodeContext?: {
@@ -185,6 +187,7 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
   children,
   defaultPinnedTrackIds,
   decorateTrack,
+  timelineRulerOverlay,
   fileName,
   episodeContext,
   headerActions,
@@ -595,6 +598,7 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
                                   key={playbackShellKey}
                                   fileName={fileName}
                                   decorateTrack={decorateTrack}
+                                  timelineRulerOverlay={timelineRulerOverlay}
                                   headerCaption={headerCaption}
                                   headerActions={
                                     <HeaderActions

--- a/app/packages/multimodal/src/views/episode/tiles/TileMediaEpisodePublisher.tsx
+++ b/app/packages/multimodal/src/views/episode/tiles/TileMediaEpisodePublisher.tsx
@@ -1,0 +1,59 @@
+import { usePlayback } from "@fiftyone/playback";
+import { useSetAtom } from "jotai";
+import React, { useEffect, useRef } from "react";
+import {
+  tileMediaEpisodeAtom,
+  type TileMediaEpisode,
+} from "../../../extensions/tiles/media-surfaces";
+import { useSceneInventory } from "../../../scene-inventory/react";
+import { timelineSecondsForContentTimeNs } from "../playback/content-time-seek";
+import { useDataStream } from "../playback/data-stream-context";
+import { useOpenImageTile } from "./use-open-image-tile";
+
+/**
+ * Publishes the episode's media commands into
+ * `extensions/tiles/media-surfaces` while the episode is mounted. The
+ * playback, tiling, and inventory hooks it wraps all throw outside their
+ * providers, which is why the commands travel through an atom instead of
+ * being called directly by a consumer elsewhere in the tree. Mounted by
+ * `PlaybackShell` inside its tiling scope.
+ */
+export const TileMediaEpisodePublisher: React.FC = () => {
+  const { pause, seek } = usePlayback();
+  const openImageTile = useOpenImageTile();
+  const sources = useSceneInventory();
+  const dataStream = useDataStream();
+  const setEpisode = useSetAtom(tileMediaEpisodeAtom);
+
+  // The command closures read refs so the published object survives
+  // per-frame churn in its inputs.
+  const latest = useRef({ openImageTile, sources, dataStream });
+  useEffect(() => {
+    latest.current = { openImageTile, sources, dataStream };
+  });
+
+  useEffect(() => {
+    const episode: TileMediaEpisode = {
+      openTileForSource: (source) => {
+        const match = latest.current.sources.find(
+          (s) => s.type === source.type && s.sourceName === source.name,
+        );
+        if (match) latest.current.openImageTile(match.id);
+      },
+      seekToTimeNs: (timeNs) => {
+        pause();
+        const index = latest.current.dataStream?.getTimelineIndex();
+        if (index) seek(timelineSecondsForContentTimeNs(index, timeNs));
+      },
+      secondsForTimestamp: (timeNs) => {
+        const index = latest.current.dataStream?.getTimelineIndex();
+        return index ? timelineSecondsForContentTimeNs(index, timeNs) : null;
+      },
+      pause,
+    };
+    setEpisode(episode);
+    return () => setEpisode(null);
+  }, [pause, seek, setEpisode]);
+
+  return null;
+};

--- a/app/packages/multimodal/src/views/episode/tiles/tile-media-surfaces.test.tsx
+++ b/app/packages/multimodal/src/views/episode/tiles/tile-media-surfaces.test.tsx
@@ -1,0 +1,133 @@
+import { TileIdScope, TilingProvider } from "@fiftyone/tiling";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  useTileMediaSurfaces,
+  type TileMediaSurface,
+} from "../../../extensions/tiles/media-surfaces";
+import type { SceneSource } from "../../../scene-inventory";
+import {
+  useRegisterTileMediaSurface,
+  type TileMediaSurfaceConfig,
+} from "./tile-media-surfaces";
+
+function imageSource(id: string): SceneSource {
+  return { id, label: id.toUpperCase(), sourceName: id, type: "image" };
+}
+
+/** An element whose layout box the test controls (jsdom reports zeros). */
+function fakeViewport(width: number, height: number): HTMLDivElement {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () =>
+    ({
+      width,
+      height,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height,
+    }) as DOMRect;
+  return el;
+}
+
+const Registrar: React.FC<{ config: TileMediaSurfaceConfig }> = ({
+  config,
+}) => {
+  useRegisterTileMediaSurface(config);
+  return null;
+};
+
+const baseConfig = (element: HTMLElement): TileMediaSurfaceConfig => ({
+  element,
+  source: imageSource("cam_front"),
+  imageSize: { width: 1000, height: 500 },
+  fit: "contain",
+  viewTransform: { scale: 1, translateX: 0, translateY: 0 },
+  contentTimeNs: 42n,
+});
+
+/** A registering tile plus a sibling consumer in the same tiling store. */
+function harness(config: TileMediaSurfaceConfig) {
+  const surfaces: TileMediaSurface[] = [];
+  const Capture: React.FC = () => {
+    const current = useTileMediaSurfaces();
+    surfaces.length = 0;
+    surfaces.push(...current);
+    return null;
+  };
+  const ui = (cfg: TileMediaSurfaceConfig) => (
+    <TilingProvider>
+      <TileIdScope tileId="image-1">
+        <Registrar config={cfg} />
+      </TileIdScope>
+      <Capture />
+    </TilingProvider>
+  );
+  const view = render(ui(config));
+  return {
+    surfaces,
+    rerender: (cfg: TileMediaSurfaceConfig) => view.rerender(ui(cfg)),
+  };
+}
+
+describe("useRegisterTileMediaSurface", () => {
+  afterEach(cleanup);
+
+  it("publishes the tile's semantic identity while bound, cleans up when unbound", () => {
+    const element = fakeViewport(200, 200);
+    const { surfaces, rerender } = harness(baseConfig(element));
+    expect(surfaces).toHaveLength(1);
+    expect(surfaces[0]).toMatchObject({
+      tileId: "image-1",
+      source: { type: "image", name: "cam_front" },
+      element,
+    });
+
+    rerender({ ...baseConfig(element), source: null });
+    expect(surfaces).toHaveLength(0);
+  });
+
+  it("computes the letterboxed media rect through the pan/zoom transform", () => {
+    // 1000×500 media contained in a 200×200 viewport → 200×100 at y=50.
+    const { surfaces } = harness(baseConfig(fakeViewport(200, 200)));
+    expect(surfaces[0].getMediaRect()).toEqual({
+      left: 0,
+      top: 50,
+      width: 200,
+      height: 100,
+    });
+  });
+
+  it("returns no rect before the media has loaded", () => {
+    const { surfaces } = harness({
+      ...baseConfig(fakeViewport(200, 200)),
+      imageSize: null,
+    });
+    expect(surfaces[0].getMediaRect()).toBeNull();
+  });
+
+  it("reads per-frame values through the live config, not the mount-time one", () => {
+    const element = fakeViewport(200, 200);
+    const config = baseConfig(element);
+    const { surfaces, rerender } = harness(config);
+    const surface = surfaces[0];
+    expect(surface.getContentTimeNs()).toBe(42n);
+
+    // A 2× zoom re-renders the tile; the SAME surface object must see it.
+    rerender({
+      ...config,
+      contentTimeNs: 99n,
+      viewTransform: { scale: 2, translateX: 10, translateY: 0 },
+    });
+    expect(surfaces[0]).toBe(surface);
+    expect(surface.getContentTimeNs()).toBe(99n);
+    expect(surface.getMediaRect()).toEqual({
+      // contain rect (0, 50, 200×100) scaled 2× about its center, +10px x.
+      left: -90,
+      top: 0,
+      width: 400,
+      height: 200,
+    });
+  });
+});

--- a/app/packages/multimodal/src/views/episode/tiles/tile-media-surfaces.ts
+++ b/app/packages/multimodal/src/views/episode/tiles/tile-media-surfaces.ts
@@ -1,0 +1,95 @@
+import { useTileId } from "@fiftyone/tiling";
+import { useStore } from "jotai";
+import { useEffect, useRef } from "react";
+import {
+  tileMediaSurfacesAtom,
+  type TileMediaSurface,
+} from "../../../extensions/tiles/media-surfaces";
+import type { SceneSource } from "../../../ir";
+import {
+  imageDisplayRect,
+  transformedImageDisplayRect,
+  type ImageDisplaySize,
+  type ImageViewTransform,
+} from "../../../visualization/media-2d/Base2dScene";
+
+/** What a registering tile knows about its own media presentation. */
+export type TileMediaSurfaceConfig = {
+  /** The tile's media viewport element (null while unmounted). */
+  element: HTMLElement | null;
+  /** The scene source the tile currently displays (null while unbound). */
+  source: SceneSource | null;
+  /** Natural media dimensions (null until the first frame loads). */
+  imageSize: ImageDisplaySize | null;
+  fit: "contain" | "cover";
+  viewTransform: ImageViewTransform;
+  /** Content time of the displayed frame, or null. */
+  contentTimeNs: bigint | null;
+};
+
+/**
+ * Publishes the surrounding tile's media surface into
+ * `extensions/tiles/media-surfaces` while it is mounted and bound to a
+ * source. Per-frame and per-gesture values (rect inputs, content time) are
+ * read through a ref by the getters, so the entry itself is republished only
+ * when the tile's identity changes. Mirrors `tile-source-bindings.ts`.
+ */
+export function useRegisterTileMediaSurface(
+  config: TileMediaSurfaceConfig,
+): void {
+  const tileId = useTileId();
+  const store = useStore();
+
+  const configRef = useRef(config);
+  useEffect(() => {
+    configRef.current = config;
+  });
+
+  const { element } = config;
+  const sourceType = config.source?.type ?? null;
+  const sourceName = config.source?.sourceName ?? null;
+
+  useEffect(() => {
+    if (!tileId || !element || sourceType === null || sourceName === null) {
+      return undefined;
+    }
+    const surface: TileMediaSurface = {
+      tileId,
+      source: { type: sourceType, name: sourceName },
+      element,
+      getMediaRect: () => {
+        const current = configRef.current;
+        if (!current.element || !current.imageSize) return null;
+        const box = current.element.getBoundingClientRect();
+        if (box.width <= 0 || box.height <= 0) return null;
+        const rect = transformedImageDisplayRect(
+          imageDisplayRect(
+            { width: box.width, height: box.height },
+            current.imageSize,
+            current.fit,
+          ),
+          current.viewTransform,
+        );
+        return {
+          left: rect.x,
+          top: rect.y,
+          width: rect.width,
+          height: rect.height,
+        };
+      },
+      getContentTimeNs: () => configRef.current.contentTimeNs,
+    };
+    store.set(tileMediaSurfacesAtom, (prev) => ({
+      ...prev,
+      [tileId]: surface,
+    }));
+    return () => {
+      store.set(tileMediaSurfacesAtom, (prev) => {
+        if (prev[tileId] !== surface) return prev;
+        const next = { ...prev };
+        delete next[tileId];
+        return next;
+      });
+    };
+  }, [tileId, element, sourceType, sourceName, store]);
+}

--- a/app/packages/playback/index.ts
+++ b/app/packages/playback/index.ts
@@ -64,6 +64,8 @@ export type {
   TimelineDisplayConversion,
   TimelineDisplayValue,
 } from "./src/lib/playback/timeline-display";
+export { laneLeftCalc } from "./src/views/utils/timeline-utils";
+export { formatTime } from "./src/views/TimelineControls/timeline-controls-utils";
 export { usePlaybackStream } from "./src/lib/playback/use-playback-stream";
 export type { AudioAvailability } from "./src/lib/playback/atoms";
 export { useAudioStream } from "./src/lib/playback/use-audio-stream";


### PR DESCRIPTION
## 🔗 Related Issues

No GitHub issues to link. Jira: [FOEPD-4332](https://voxel51.atlassian.net/browse/FOEPD-4332) (spatiotemporal comments, Enterprise). Companion to voxel51/fiftyone-teams#3970, which currently carries these hooks as Enterprise edits to OSS-shared files; once this syncs, that PR's multimodal edits go away.

## 📋 What changes are proposed in this pull request?

Two small extension points in `@fiftyone/multimodal` for features hosted outside the package that need to draw over a tile's media, or mark instants on the episode ruler. Modeled on the existing extension seams (sidebar trays, timeline contributions): the shared layer publishes facts and exposes slots; it knows nothing about what a consumer does with them. Open source registers nothing, so nothing changes in the OSS app.

**Tile media surfaces** — `extensions/tiles/media-surfaces.ts`. Each mounted 2D-media tile publishes where it draws its stream: the viewport element, a live media rect (letterbox + pan/zoom applied, read per animation frame), and the content time of the displayed frame. The playback shell publishes the episode's media commands: open or focus the tile for a stream, seek to a content time (landing on the tick at or after it, so the presented frame is the one asked for), and pause. Publishers are `useRegisterTileMediaSurface` (called from `ImageTile`) and `TileMediaEpisodePublisher` (mounted by `PlaybackShell` inside its tiling scope). Consumers use `useTileMediaSurfaces()` / `useTileMediaEpisode()` from `@fiftyone/multimodal/extensions/tiles`. Entries live in the tiling shell's per-instance jotai store, so they are scoped to one episode modal and vanish with it.

**Ruler overlay** — `TimelineContribution.rulerOverlay?: (labelWidth: number) => ReactNode`. A registered timeline extension may render over the episode ruler at the ruler's live label width. Composed in the timeline host alongside `runtime`, threaded through `ModalRenderer → SourcePlayback → PlaybackShell` next to `decorateTrack`, and handed to the timeline's existing `rulerOverlay` render prop.

Both live under existing exported, facade-listed entrypoints (`./extensions/tiles`, `./extensions/timeline`), so there are no `package.json` or `.dependency-cruiser.cjs` changes. `@fiftyone/playback` additionally exports `laneLeftCalc` and `formatTime`, which a ruler overlay needs to position and label itself consistently with the ruler.

**Design question for reviewers:** the ruler slot is the one optional piece. The alternative is for instant markers to ride the episode-intervals seam from #8371 as a track section once that lands. That gives a track row (and grid-tile marks) rather than diamonds on the ruler, which is a different UX; the slot keeps both options open. Happy to drop it if you'd rather not add a contribution field for this.

## 🧪 How is this patch tested? If it is not, please explain why.

- New `tile-media-surfaces.test.tsx`: publishes and unpublishes with the tile's binding, computes the letterboxed rect through the pan/zoom transform, returns no rect before media loads, and reads per-frame values through the live config without republishing the entry.
- `app/packages/multimodal` gates all pass: types, lint, dependency policy, dependency architecture, bounded reads.
- Full `packages/multimodal` and `packages/playback` suites green (4,193 tests), including `PlaybackShell`, `SourcePlayback`, the `SourcePlayback` integration test, and the timeline host tests with the new contribution field.
- Manual: the Enterprise spatiotemporal comments feature is the first consumer; it is running against the equivalent hooks on an ephemeral environment. Its port onto these seams will be the follow-up on the Enterprise side.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


[FOEPD-4332]: https://voxel51.atlassian.net/browse/FOEPD-4332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3990
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying overlays and controls on 2D media tiles in episode views.
  - Added episode-level media actions, including opening tiles, seeking, and pausing playback.
  - Added timeline ruler overlays that adapt to the ruler’s live label width.
  - Media tiles now support external overlays while preserving pan, zoom, source, and timestamp information.

- **Bug Fixes**
  - Improved content-time seeking to select the correct timeline position and avoid nearest-tick misses.

- **Documentation**
  - Documented media-tile surfaces, episode controls, overlay usage, and timeline ruler overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->