### PR TITLE
Fix NaN confidences from mixed-precision classifiers

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1384,7 +1384,12 @@ class ClassifierOutputProcessor(OutputProcessor):
         logits = output.detach().cpu().numpy()
 
         predictions = np.argmax(logits, axis=1)
-        odds = np.exp(logits)
+        # Shift by the row maximum before exponentiating, and do it in at least
+        # float32. Half-precision logits, which any model that runs under
+        # `torch.amp.autocast` produces, overflow `np.exp` and leave every
+        # confidence NaN; the shift also keeps large float32 logits finite
+        scaled = logits.astype(np.float32, copy=False)
+        odds = np.exp(scaled - np.max(scaled, axis=1, keepdims=True))
         odds /= np.sum(odds, axis=1, keepdims=True)
         scores = np.max(odds, axis=1)
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -42,7 +42,6 @@ import torchvision
 from torchvision.models.feature_extraction import create_feature_extractor
 from torchvision.transforms import functional as F
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -1388,7 +1387,8 @@ class ClassifierOutputProcessor(OutputProcessor):
         # float32. Half-precision logits, which any model that runs under
         # `torch.amp.autocast` produces, overflow `np.exp` and leave every
         # confidence NaN; the shift also keeps large float32 logits finite
-        scaled = logits.astype(np.float32, copy=False)
+        dtype = np.promote_types(logits.dtype, np.float32)
+        scaled = logits.astype(dtype, copy=False)
         odds = np.exp(scaled - np.max(scaled, axis=1, keepdims=True))
         odds /= np.sum(odds, axis=1, keepdims=True)
         scores = np.max(odds, axis=1)

--- a/tests/unittests/utils/test_classifier_output.py
+++ b/tests/unittests/utils/test_classifier_output.py
@@ -1,0 +1,104 @@
+"""
+Tests for fiftyone/utils/torch.py ClassifierOutputProcessor.
+
+| Copyright 2017-2026, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import fiftyone.core.labels as fol
+
+
+def _processor(classes=None, store_logits=False):
+    from fiftyone.utils.torch import ClassifierOutputProcessor
+
+    return ClassifierOutputProcessor(
+        classes=classes or ["cat", "dog", "bird"], store_logits=store_logits
+    )
+
+
+class TestClassifierOutputProcessor:
+    def test_requires_classes(self):
+        from fiftyone.utils.torch import ClassifierOutputProcessor
+
+        with pytest.raises(ValueError, match="requires class labels"):
+            ClassifierOutputProcessor(classes=None)
+
+    def test_confidence_matches_softmax(self):
+        processor = _processor()
+        logits = torch.tensor([[1.0, 3.0, 2.0]])
+
+        preds = processor(logits, None)
+
+        expected = torch.softmax(logits, dim=1).max().item()
+        assert preds[0].label == "dog"
+        assert preds[0].confidence == pytest.approx(expected, abs=1e-6)
+
+    def test_half_precision_logits_are_finite(self):
+        # A model running under torch.amp.autocast emits half-precision
+        # logits; exponentiating them directly overflows and yields NaN
+        processor = _processor()
+        logits = torch.tensor([[10.0, 23.4, 5.0]], dtype=torch.float16)
+
+        preds = processor(logits, None)
+
+        assert preds[0].label == "dog"
+        assert np.isfinite(preds[0].confidence)
+        assert 0.0 <= preds[0].confidence <= 1.0
+        expected = torch.softmax(logits.float(), dim=1).max().item()
+        assert preds[0].confidence == pytest.approx(expected, abs=1e-3)
+
+    def test_large_logits_are_finite(self):
+        processor = _processor()
+        logits = torch.tensor([[500.0, 100.0, 0.0]])
+
+        preds = processor(logits, None)
+
+        assert preds[0].label == "cat"
+        assert preds[0].confidence == pytest.approx(1.0)
+
+    def test_batch_is_scored_per_row(self):
+        processor = _processor()
+        logits = torch.tensor([[5.0, 0.0, 0.0], [0.0, 0.0, 5.0]])
+
+        preds = processor(logits, None)
+
+        assert [p.label for p in preds] == ["cat", "bird"]
+        assert all(np.isfinite(p.confidence) for p in preds)
+
+    def test_confidence_thresh_blanks_the_label(self):
+        processor = _processor()
+        logits = torch.tensor([[1.0, 1.1, 1.0]])
+
+        preds = processor(logits, None, confidence_thresh=0.9)
+
+        assert preds[0].label is None
+
+    def test_class_filter_blanks_the_label(self):
+        processor = _processor()
+        logits = torch.tensor([[1.0, 3.0, 2.0]])
+
+        preds = processor(logits, None, classes=["cat"])
+
+        assert preds[0].label is None
+
+    def test_logits_are_stored_when_requested(self):
+        processor = _processor(store_logits=True)
+        logits = torch.tensor([[1.0, 3.0, 2.0]])
+
+        preds = processor(logits, None)
+
+        assert isinstance(preds[0], fol.Classification)
+        np.testing.assert_allclose(preds[0].logits, [1.0, 3.0, 2.0])
+
+    def test_dict_output_is_unwrapped(self):
+        processor = _processor()
+        logits = torch.tensor([[1.0, 3.0, 2.0]])
+
+        preds = processor({"logits": logits}, None)
+
+        assert preds[0].label == "dog"

--- a/tests/unittests/utils/test_classifier_output.py
+++ b/tests/unittests/utils/test_classifier_output.py
@@ -61,6 +61,17 @@ class TestClassifierOutputProcessor:
         assert preds[0].label == "cat"
         assert preds[0].confidence == pytest.approx(1.0)
 
+    def test_double_precision_logits_keep_their_precision(self):
+        # Widening to float32 must not narrow logits that arrive wider
+        processor = _processor()
+        logits = torch.tensor([[20.0, 1.0, 0.5]], dtype=torch.float64)
+
+        preds = processor(logits, None)
+
+        expected = torch.softmax(logits, dim=1).max().item()
+        assert preds[0].confidence == pytest.approx(expected, abs=1e-12)
+        assert preds[0].confidence < 1.0
+
     def test_batch_is_scored_per_row(self):
         processor = _processor()
         logits = torch.tensor([[5.0, 0.0, 0.0], [0.0, 0.0, 5.0]])


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

`ClassifierOutputProcessor` exponentiates the raw logits before normalizing
them:

```python
odds = np.exp(logits)
odds /= np.sum(odds, axis=1, keepdims=True)
```

Any model that runs under `torch.amp.autocast` hands it half-precision
logits, and `np.exp` overflows float16 above about 11, so `odds` becomes
`inf`, the division becomes `inf / inf`, and every confidence is `NaN`. The
label is still correct, since `argmax` runs before the overflow, so the
prediction looks healthy until something downstream thresholds, sorts or
averages the confidence.

`open-clip-torch` hits this on any CUDA device: `TorchOpenClipModel._predict_all`
enters `torch.amp.autocast` when the model is on GPU, so its logits reach the
processor as float16.

```python
model = foz.load_zoo_model("open-clip-torch", device="cuda")
model.predict(image).confidence   # nan
```

The fix subtracts the row maximum before exponentiating and does the
arithmetic in float32. That is the standard stable softmax, so float32
confidences are unchanged to within rounding, float16 logits now produce the
same values as float32, and large float32 logits no longer overflow.

Measured on the same image with `open-clip-torch` on an RTX 6000 Ada, before
and after: `nan` and `nan` become `0.8282` and `0.7282`, matching the CPU
result of `0.8293`. `clip-vit-base32-torch`, `siglip-base-patch16-224-torch`
and `resnet50-imagenet-torch` are unchanged to seven decimal places.

## 🧪 How is this patch tested? If it is not, please explain why.

- `tests/unittests/utils/test_classifier_output.py` covers the processor:
  confidences match `torch.softmax`, half-precision logits stay finite and
  agree with the float32 result, large logits stay finite, batches are scored
  per row, and the threshold, class-filter, stored-logits and dict-input
  paths still behave.
- Ran the five classification and zero-shot zoo models above on GPU with the
  stock wrapper and with this branch, comparing confidences.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Fixed `NaN` confidences from classification models running in mixed
      precision, which affected `open-clip-torch` on any CUDA device.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3991
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed classification confidence calculations for half-precision and very large logits, preventing invalid NaN confidence values.
  - Improved confidence scoring across batched predictions.

- **Tests**
  - Added coverage for confidence calculations, thresholds, class filtering, stored logits, and dictionary-based model outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->