### PR TITLE
Fix unclickable checkbox-list attributes after a conditional attribute is hidden and re-shown

### DIFF
--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/CheckboxesWidget.test.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/CheckboxesWidget.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render } from "@testing-library/react";
+import type { WidgetProps } from "@rjsf/utils";
+import { describe, expect, it, vi } from "vitest";
+import CheckboxesWidget from "./CheckboxesWidget";
+
+const schema = {
+  type: "array",
+  items: { type: "string", enum: ["missing", "duplicated", "jitter"] },
+};
+
+const renderWidget = (value: unknown, onChange = vi.fn()) => {
+  const { container } = render(
+    <CheckboxesWidget
+      {...({
+        id: "glitch_kind",
+        label: "glitch_kind",
+        schema,
+        value,
+        onChange,
+      } as unknown as WidgetProps)}
+    />,
+  );
+
+  // The widget ids each headlessui control as `${id}-${value}`; that element
+  // carries role="checkbox" and aria-checked.
+  const box = (name: string) => {
+    const el = container.querySelector<HTMLElement>(`#glitch_kind-${name}`);
+    if (!el) throw new Error(`no checkbox for ${name}`);
+    return el;
+  };
+  const isChecked = (name: string) =>
+    box(name).getAttribute("aria-checked") === "true";
+
+  return { onChange, box, isChecked };
+};
+
+describe("CheckboxesWidget", () => {
+  it("renders every enum option unchecked when value is undefined", () => {
+    const { isChecked } = renderWidget(undefined);
+    expect(isChecked("missing")).toBe(false);
+    expect(isChecked("duplicated")).toBe(false);
+    expect(isChecked("jitter")).toBe(false);
+  });
+
+  it("checks the options present in value", () => {
+    const { isChecked } = renderWidget(["jitter"]);
+    expect(isChecked("jitter")).toBe(true);
+    expect(isChecked("missing")).toBe(false);
+  });
+
+  it("toggling from a null value emits a one-element array instead of throwing", () => {
+    // Regression: the annotate edit form writes an explicit `null` when a
+    // conditional attribute is hidden. A destructuring default only covers
+    // `undefined`, so `values.map` used to throw and the click was swallowed.
+    const { onChange, box } = renderWidget(null);
+
+    fireEvent.click(box("missing"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(["missing"]);
+  });
+
+  it("adds and removes values preserving enum order", () => {
+    const { onChange, box } = renderWidget(["jitter"]);
+
+    fireEvent.click(box("missing"));
+    expect(onChange).toHaveBeenLastCalledWith(["missing", "jitter"]);
+
+    fireEvent.click(box("jitter"));
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+});

--- a/app/packages/components/src/components/SmartForm/RJSF/widgets/CheckboxesWidget.tsx
+++ b/app/packages/components/src/components/SmartForm/RJSF/widgets/CheckboxesWidget.tsx
@@ -28,7 +28,7 @@ interface ItemsSchema {
 export default function CheckboxesWidget(props: WidgetProps) {
   const {
     label,
-    value: values = [], // use plural for internal cohesiveness
+    value,
     disabled,
     readonly,
     onChange = () => {},
@@ -41,6 +41,16 @@ export default function CheckboxesWidget(props: WidgetProps) {
   const enumNames = items.enumNames || enumValues;
 
   const isDisabled = disabled || readonly;
+
+  // A destructuring default only covers `undefined`. The annotate edit form
+  // writes an explicit `null` when a conditional attribute is hidden (so the
+  // autosave delta carries an unset), and SDK-written labels can hold `None`.
+  // Treat both as "nothing selected" so the toggle handler never dereferences
+  // a null value.
+  const values = useMemo<unknown[]>(
+    () => (Array.isArray(value) ? value : []),
+    [value],
+  );
 
   const options = useMemo<Option[]>(
     () =>
@@ -55,7 +65,7 @@ export default function CheckboxesWidget(props: WidgetProps) {
   // convert values to string for comparison.
   const validStringValues = useMemo(
     // handle strings, ints, etc., de-duping as we goa
-    () => new Set((values ?? []).map((v: unknown) => String(v))),
+    () => new Set(values.map((v: unknown) => String(v))),
     [values],
   );
 

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.test.ts
@@ -951,6 +951,112 @@ describe("applyConditionalOwnerChange", () => {
     });
   });
 
+  // ── Branch 2b: list attribute re-shown after being nulled ────────────────
+
+  describe("list attribute re-shown after the hide branch nulled it", () => {
+    // Mirrors the gm-segment-issue ontology: `glitch_kind` is a checkbox list
+    // gated on label == "object_glitch" with no default.
+    const listAttributes: AttributeConfig[] = [
+      {
+        name: "label",
+        type: "str",
+        component: "dropdown",
+        values: ["object_glitch", "sensor_dropout"],
+      },
+      {
+        name: "glitch_kind",
+        type: "list<str>",
+        component: "checkboxes",
+        values: ["missing", "duplicated"],
+        when: {
+          operator: "equals" as const,
+          field: "label",
+          value: "object_glitch",
+        },
+      },
+      {
+        name: "glitch_kind_with_default",
+        type: "list<str>",
+        component: "checkboxes",
+        values: ["missing", "duplicated"],
+        default: ["missing"],
+        when: {
+          operator: "equals" as const,
+          field: "label",
+          value: "object_glitch",
+        },
+      },
+    ];
+
+    it("restores [] (not null) when a defaultless list attribute becomes visible again", () => {
+      const prevData = { label: "sensor_dropout", glitch_kind: null };
+      const nextValue: Record<string, unknown> = {
+        label: "object_glitch",
+        glitch_kind: null,
+      };
+
+      applyConditionalOwnerChange(
+        "glitch_kind",
+        listAttributes,
+        prevData,
+        nextValue,
+      );
+
+      expect(nextValue.glitch_kind).toEqual([]);
+    });
+
+    it("prefers the configured default over [] for list attributes", () => {
+      const prevData = {
+        label: "sensor_dropout",
+        glitch_kind_with_default: null,
+      };
+      const nextValue: Record<string, unknown> = {
+        label: "object_glitch",
+        glitch_kind_with_default: null,
+      };
+
+      applyConditionalOwnerChange(
+        "glitch_kind_with_default",
+        listAttributes,
+        prevData,
+        nextValue,
+      );
+
+      expect(nextValue.glitch_kind_with_default).toEqual(["missing"]);
+    });
+
+    it("leaves an undefined (never set) list attribute alone", () => {
+      const prevData = { label: "sensor_dropout" };
+      const nextValue: Record<string, unknown> = { label: "object_glitch" };
+
+      applyConditionalOwnerChange(
+        "glitch_kind",
+        listAttributes,
+        prevData,
+        nextValue,
+      );
+
+      expect(nextValue.glitch_kind).toBeUndefined();
+    });
+
+    it("still writes null (not []) when the list attribute is hidden", () => {
+      const prevData = { label: "object_glitch", glitch_kind: ["missing"] };
+      const nextValue: Record<string, unknown> = {
+        label: "sensor_dropout",
+        glitch_kind: ["missing"],
+      };
+
+      applyConditionalOwnerChange(
+        "glitch_kind",
+        listAttributes,
+        prevData,
+        nextValue,
+      );
+
+      expect(nextValue.glitch_kind).toBeNull();
+    });
+  });
+
   // ── Branch 2: became visible with no value ───────────────────────────────
 
   describe("became visible with null value (prevOwner === undefined && currentOwner && value[name] == null)", () => {

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/evaluateWhen.ts
@@ -216,8 +216,22 @@ export function applyConditionalOwnerChange(
     const defaultVal = currentOwner.default;
     if (defaultVal !== undefined) {
       nextValue[name] = defaultVal;
+    } else if (nextValue[name] === null && isListType(currentOwner.type)) {
+      // The hide branch above left an explicit `null` behind. For list
+      // attributes that is not a well-typed empty value — checkbox lists and
+      // tag inputs expect an array — so restore `[]` when the slot re-opens.
+      // `undefined` (never set) is left alone so fresh labels don't persist
+      // empty arrays they never touched.
+      nextValue[name] = [];
     }
   }
+}
+
+/**
+ * Returns true for list attribute types (`list<str>`, `list<int>`, ...).
+ */
+function isListType(type: string | undefined): boolean {
+  return typeof type === "string" && type.startsWith("list<");
 }
 
 /**


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link

## 📋 What changes are proposed in this pull request?

In the Annotate edit panel, a `list<str>` / `list<int>` / `list<float>` attribute rendered with the `checkboxes` component could render but ignore clicks, with `TypeError: Cannot read properties of null (reading 'map')` in the console.

Two pieces disagreed about what "empty" means for a list attribute:

- When an attribute's `when` condition stops being satisfied, the edit form writes an explicit `null` so the autosave delta carries an unset. When the condition is satisfied again, a value was only restored if the attribute defined a `default`, so list attributes were left as `null`.
- `CheckboxesWidget` used a destructuring default (`value = []`), which only covers `undefined`. The render path tolerated `null`, but the toggle handler called `values.map(...)` directly and threw.

Changes:

- `CheckboxesWidget`: normalize any non-array value to `[]` before the render and toggle paths use it. This also covers labels written from the SDK with a list attribute set to `None`.
- `applyConditionalOwnerChange`: when a defaultless `list<*>` attribute becomes visible again and was nulled by the hide branch, restore `[]`. Values that were never set stay `undefined`, so fresh labels don't persist empty arrays they never touched. The hide behaviour (writing `null` rather than deleting) is unchanged.

### Reproduction

The script below builds a dataset with a conditional checkbox-list attribute and seeds one detection with the attribute set to `None`, which is the state the UI leaves behind after hiding and re-showing the attribute.

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", dataset_name="checkboxes-repro")
dataset.persistent = True

# Declare the list attribute on the detections
dataset.add_sample_field(
    "ground_truth.detections.issue_kind", fo.ListField, subfield=fo.StringField
)

# Ontology: `issue_kind` is a checkbox list shown only when label == "glitch"
ontology = fo.AnnotationOntology(
    name="checkboxes-repro",
    attributes=[
        fo.AttributeSpec(
            name="issue_kind",
            type="list<str>",
            component="checkboxes",
            values=["missing", "duplicated", "jitter"],
            when=fo.WhenEquals(field="label", value="glitch"),
        ),
    ],
)
ontology.save(overwrite=True)

label_schemas = {
    "ground_truth": {
        "type": "detections",
        "component": "dropdown",
        "classes": ["glitch", "other"],
    }
}
dataset.set_label_schemas(
    fo.apply_ontology(label_schemas, "ground_truth", ontology.name)
)
dataset.activate_label_schemas(["ground_truth"])

# Seed the broken state directly: an explicit None on the list attribute
sample = dataset.first()
det = sample.ground_truth.detections[0]
det.label = "glitch"
det["issue_kind"] = None
sample.save()

session = fo.launch_app(dataset)
```

Then in the App: open the first sample, switch to Annotate, select the first `ground_truth` detection, and click any `issue_kind` checkbox.

- On `main`: nothing happens and the console shows the `TypeError`.
- With this PR: the checkbox toggles and the value saves.

To reproduce through the UI alone, skip the seeding block: select a detection, set its label to `glitch`, change it to `other` (hiding `issue_kind`), then back to `glitch`.

## 🧪 How is this patch tested? If it is not, please explain why.

- New `CheckboxesWidget.test.tsx`: renders, checked state from value, toggling from `null` emits `["value"]` (fails on `main`), add/remove preserves enum order.
- `evaluateWhen.test.ts`: four cases for the list re-show path (restores `[]`, prefers a configured default, leaves `undefined` alone, hide still writes `null`).
- Manually reproduced with the script above and confirmed the console error before the fix.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)
