### PR TITLE
Results list never scrolls horizontally (FOEPD-4577)

### DIFF
--- a/app/packages/components/src/components/Results/Results.module.css
+++ b/app/packages/components/src/components/Results/Results.module.css
@@ -11,7 +11,10 @@
 }
 
 .scrollContainer {
-  overflow: auto;
+  /* a horizontal scrollbar and the vertical one toggle each other at the
+     max-height boundary, oscillating the layer; rows truncate instead */
+  overflow-x: hidden;
+  overflow-y: auto;
   max-height: 250px;
 }
 
@@ -41,6 +44,7 @@
 .resultComponent {
   overflow: hidden;
   white-space: nowrap;
+  min-width: 0;
   max-width: 100%;
   text-overflow: ellipsis;
 }

--- a/app/packages/components/src/components/Results/Results.tsx
+++ b/app/packages/components/src/components/Results/Results.tsx
@@ -57,7 +57,7 @@ export function Result<T>({
       className={classNames(...classes)}
       ref={ref}
     >
-      <Component value={result} />
+      <Component value={result} className={style.resultComponent} />
     </div>
   );
 }

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/GroupAnnotation.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/GroupAnnotation.tsx
@@ -38,15 +38,22 @@ const sliceOptionSuffix = ({ isSupported, isMissing }: AnnotationSliceInfo) => {
   return null;
 };
 
-const SliceOption = ({ info }: { info: AnnotationSliceInfo }) => {
+const SliceOption = ({
+  className,
+  info,
+}: {
+  className?: string;
+  info: AnnotationSliceInfo;
+}) => {
   const isDisabled = info.isMissing || !info.isSupported;
   return (
     <span
+      className={className}
       style={{
         opacity: isDisabled ? 0.5 : 1,
         cursor: isDisabled ? "not-allowed" : "pointer",
       }}
-      title={sliceOptionTitle(info)}
+      title={sliceOptionTitle(info) ?? info.name}
     >
       {info.name}
       {sliceOptionSuffix(info)}
@@ -121,8 +128,8 @@ export default function GroupAnnotation({
 
   const SliceOptionComponent = useMemo(
     () =>
-      ({ value }: { value: string }) => (
-        <SliceOption info={sliceInfoMap[value]} />
+      ({ className, value }: { className?: string; value: string }) => (
+        <SliceOption className={className} info={sliceInfoMap[value]} />
       ),
     [sliceInfoMap],
   );


### PR DESCRIPTION
## What changes

Fixes [FOEPD-4577](https://voxel51.atlassian.net/browse/FOEPD-4577): in Annotate on a grouped dataset with long slice names, the slice selector dropdown oscillates ("wiggles") when the list height sits at the scrollbar toggle boundary.

**Cause.** The shared `Selector` results list (`Results.module.css` `.scrollContainer`) was `overflow: auto` with nowrap rows. Long names produced a horizontal scrollbar whose height sat right at the 250px `max-height` boundary, so it toggled the vertical scrollbar, which changed the width, which toggled the horizontal one again on every layout pass.

**Fix.**
- `Results.module.css`: the list is `overflow-x: hidden; overflow-y: auto`, so the vertical scrollbar depends only on row count and can never flip. The existing `resultComponent` ellipsis class gains `min-width: 0` so it shrinks as a flex item.
- `Results.tsx`: passes `resultComponent` as `className` to the row component. The prop was already in the component type.
- `GroupAnnotation.tsx`: the slice option applies the class and falls back to the slice name as its `title`, so truncated names are recoverable on hover.

## Scope

This touches every `Selector` dropdown (dataset selector, sidebar filters, sort, map, embeddings). Rows wider than the dropdown now truncate with an ellipsis where they used to scroll sideways. Row components that ignore `className` clip instead.

## How to test

Firefox, browser zoom 130%, a grouped dataset with ~7 slices named like `SurroundDrivePerceptionCameraForward` → sample modal → Annotate → open the slice selector. The dropdown should open and stay still; long names end in an ellipsis with the full name on hover.

[FOEPD-4577]: https://voxel51.atlassian.net/browse/FOEPD-4577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/3999
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved results layout by preventing unwanted horizontal scrolling while preserving vertical scrolling.
  - Result items can now shrink appropriately to fit narrow containers.
  - Improved styling support for rendered result components.
  - Annotation options now support custom styling and display the slice name when no descriptive title is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->