### PR TITLE
Temporal detection editor rejects a span the SDK would (FOEPD-4599)

### DIFF
--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/TemporalDetectionDetails.tsx
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/TemporalDetectionDetails.tsx
@@ -5,9 +5,16 @@ import {
   useEngineSelector,
 } from "@fiftyone/annotation";
 import type { LabelData } from "@fiftyone/utilities";
+import { ErrorSchemaBuilder } from "@rjsf/utils";
 import { useEffect, useMemo, useState } from "react";
 import { SchemaIOComponent } from "../../../../../plugins/SchemaIO";
 import { SchemaType } from "../../../../../plugins/SchemaIO/utils/types";
+import {
+  type Span,
+  type SupportBound,
+  changedBound,
+  supportError,
+} from "./supportValidation";
 import { useAnnotationContext } from "./useAnnotationContext";
 
 const createInput = (name: string, readOnly?: boolean) => {
@@ -37,9 +44,9 @@ const createStack = () => {
   };
 };
 
-interface Span {
-  start?: number;
-  stop?: number;
+interface SupportIssue {
+  bound: SupportBound;
+  message: string;
 }
 
 export interface TemporalDetectionDetailsProps {
@@ -53,12 +60,15 @@ export interface TemporalDetectionDetailsProps {
  * {@link Position} for bounding boxes. The span is read reactively from the
  * engine (so it re-syncs on number-input edits, undo/redo, and timeline drags)
  * and edits commit straight back through the engine, keeping the timeline
- * interval and persistence in step.
+ * interval and persistence in step. A span the SDK would reject (see
+ * {@link supportError}) shows a message under the edited bound and is not
+ * committed.
  */
 export default function TemporalDetectionDetails({
   readOnly = false,
 }: TemporalDetectionDetailsProps) {
   const [span, setSpan] = useState<Span>({});
+  const [issue, setIssue] = useState<SupportIssue | null>(null);
 
   const { selected } = useAnnotationContext();
   const overlay = selected?.overlay;
@@ -90,6 +100,7 @@ export default function TemporalDetectionDetails({
     }
 
     setSpan({ start: committedSupport[0], stop: committedSupport[1] });
+    setIssue(null);
   }, [committedSupport]);
 
   const schema: SchemaType = useMemo(
@@ -112,11 +123,26 @@ export default function TemporalDetectionDetails({
     [readOnly],
   );
 
+  // rendered by the form's field template under the edited bound
+  const smartFormProps = useMemo(() => {
+    if (!issue) {
+      return undefined;
+    }
+
+    return {
+      extraErrors: new ErrorSchemaBuilder().addErrors(issue.message, [
+        "support",
+        issue.bound,
+      ]).ErrorSchema,
+    };
+  }, [issue]);
+
   return (
     <div style={{ width: "100%" }}>
       <SchemaIOComponent
         key={ref?.instanceId ?? overlay?.id}
         smartForm={true}
+        smartFormProps={smartFormProps}
         schema={schema}
         data={{ support: span }}
         onChange={(input: { support?: Span }) => {
@@ -143,6 +169,15 @@ export default function TemporalDetectionDetails({
 
           // immediate display of the typed value
           setSpan(merged);
+
+          // an invalid span stays on screen with its message; the stored
+          // span is untouched until the typed values agree
+          const message = supportError(merged.start, merged.stop);
+          if (message) {
+            setIssue({ bound: changedBound(current, merged), message });
+            return;
+          }
+          setIssue(null);
 
           // commit through the engine: it persists (autosave diffs the engine)
           // and the timeline re-derives the interval. A bare updateLabel is one

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/supportValidation.test.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/supportValidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { changedBound, supportError } from "./supportValidation";
+
+describe("supportError", () => {
+  it("accepts whole frame numbers with start <= stop", () => {
+    expect(supportError(1, 1)).toBeNull();
+    expect(supportError(2, 10)).toBeNull();
+  });
+
+  it("rejects a stop before the start", () => {
+    // the Angio repro: end typed before start persisted a [20, 10] support
+    expect(supportError(20, 10)).toBe("start must not be after stop");
+  });
+
+  it("rejects a start before frame 1", () => {
+    expect(supportError(0, 5)).toBe("start must be at least 1");
+    expect(supportError(-3, 5)).toBe("start must be at least 1");
+  });
+
+  it("rejects fractional frame numbers", () => {
+    expect(supportError(1.5, 3)).toBe("frame numbers must be whole numbers");
+    expect(supportError(1, 3.2)).toBe("frame numbers must be whole numbers");
+  });
+});
+
+describe("changedBound", () => {
+  it("names the bound that differs from the current span", () => {
+    expect(changedBound({ start: 1, stop: 10 }, { start: 5, stop: 10 })).toBe(
+      "start",
+    );
+    expect(changedBound({ start: 1, stop: 10 }, { start: 1, stop: 3 })).toBe(
+      "stop",
+    );
+  });
+});

--- a/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/supportValidation.ts
+++ b/app/packages/core/src/components/Modal/Sidebar/Annotate/Edit/supportValidation.ts
@@ -1,0 +1,31 @@
+export type SupportBound = "start" | "stop";
+
+export interface Span {
+  start?: number;
+  stop?: number;
+}
+
+/**
+ * Validates a TemporalDetection's `[start, stop]` frame support the way the
+ * SDK's `FrameSupportField` does: whole frame numbers with `1 <= start <= stop`.
+ * Returns the message to show, or `null` when the span is valid.
+ */
+export const supportError = (start: number, stop: number): string | null => {
+  if (!Number.isInteger(start) || !Number.isInteger(stop)) {
+    return "frame numbers must be whole numbers";
+  }
+
+  if (start < 1) {
+    return "start must be at least 1";
+  }
+
+  if (start > stop) {
+    return "start must not be after stop";
+  }
+
+  return null;
+};
+
+/** The bound the user edited, i.e. where a message belongs. */
+export const changedBound = (current: Span, next: Span): SupportBound =>
+  next.stop !== current.stop ? "stop" : "start";


### PR DESCRIPTION
## What changes

Fixes [FOEPD-4599](https://voxel51.atlassian.net/browse/FOEPD-4599): in Annotate on a video sample, typing a TemporalDetection's stop frame before its start frame committed a `support` like `[20, 10]`. The SDK's `FrameSupportField` rejects that on every later save, so the whole sample became unsaveable ("We couldn't save your work").

**Fix.** The start/stop editor (`TemporalDetectionDetails.tsx`) now validates the merged span before committing, using the same rule as the SDK: whole frame numbers with `1 <= start <= stop`.

- An invalid span stays on screen with a message under the bound the user edited ("start must not be after stop", "start must be at least 1", "frame numbers must be whole numbers"). The stored span is untouched until the values agree.
- The message is delivered through RJSF's `extraErrors`, which the existing SmartForm field template already renders, so no new UI.
- Any committed change from elsewhere (timeline drag, undo/redo) resyncs the inputs and clears the message.
- The rule lives in `supportValidation.ts` with a unit test.

## Follow-up, not in this PR

The invalid value could persist because the ETag-protected save in `fiftyone/server/routes/sample.py` (`save_sample`) writes the raw dict with `replace_one`, which skips mongoengine validation. A server-side validation there would stop any client from storing a document the SDK cannot read back. Worth a separate ticket.

## How to test

Video dataset (e.g. quickstart-video) → sample modal → Annotate → select a temporal detection → set stop below start. The message appears under the stop field and nothing is saved; correcting the value clears it and saves. Also try `0` or `1.5` as start.

[FOEPD-4599]: https://voxel51.atlassian.net/browse/FOEPD-4599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation when editing temporal detection frame ranges.
  * Invalid ranges now show an inline error and do not overwrite the saved value.
  * Valid ranges are committed normally, and validation messages clear after correction.

* **Bug Fixes**
  * Prevented reversed, fractional, or sub-one frame ranges from being saved.

* **Tests**
  * Added coverage for valid and invalid frame ranges and edited-bound detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4000
<!-- enterprise-sync-pr:end -->