### PR TITLE
Time / frame readout toggle on the Annotate tab

### DIFF
--- a/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
+++ b/app/packages/video-annotation/src/components/VideoAnnotationSurface.tsx
@@ -13,7 +13,7 @@ import { useAnnotatePrerequisites } from "../hooks/useAnnotatePrerequisites";
 import { useDecodeStrategy } from "../hooks/useDecodeStrategy";
 import type { DecodeStrategy } from "../utils/decodeStrategy";
 import { useTimelineMaxSize } from "../hooks/useTimelineMaxSize";
-import { PlaybackProvider } from "@fiftyone/playback";
+import { PlaybackProvider, type TimelineMode } from "@fiftyone/playback";
 import {
   AnnotatePrerequisiteChecking,
   AnnotatePrerequisiteNotice,
@@ -154,6 +154,20 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
     return url ? getSampleSrc(url) : null;
   }, [sample]);
 
+  // Sequence mode makes the frame domain available to switch into, which is
+  // what turns the controls row's readout into a button (see `PlayheadTime`).
+  // `useAnnotatePrerequisites` blocks the surface unless the frame rate is
+  // finite and positive, so by the time this provider mounts there is always
+  // one — no `duration` fallback, and no remount key: the gates below hold the
+  // provider back until `frameRate` has resolved, so it never changes under it.
+  //
+  // The display still opens on timecode (`defaultDisplay` below); frames are
+  // opt-in, matching Explore.
+  const mode = useMemo<TimelineMode>(
+    () => ({ kind: "sequence", fps: prerequisites.frameRate as number }),
+    [prerequisites.frameRate],
+  );
+
   // Decide the decode strategy up front. Runs unconditionally (before the gates
   // below) to keep hook order stable across the resolving → resolved transition.
   const resolution = useDecodeStrategy({
@@ -255,7 +269,7 @@ export const VideoAnnotationSurface: React.FC<VideoAnnotationSurfaceProps> = ({
     // Annotation wants the playhead to rest on a real frame after a pause or
     // scrub-drag, so the labels snapshot and any keyframe op align to a frame.
     // Scrubbing stays continuous — only the settle position snaps.
-    <PlaybackProvider snapToFrameOnSettle>
+    <PlaybackProvider snapToFrameOnSettle mode={mode} defaultDisplay="duration">
       <VideoAnnotationHandlerRegistration />
       {AUDIO_ONLY_STRATEGIES.has(strategy) && (
         <RegisterTimelineAudio


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link. Stacked on #8342 — targets `feat/videoExploreTimeline`, not `main`, so the diff here is one commit.

## 📋 What changes are proposed in this pull request?

Annotate's timeline readout becomes a button that swaps between timecode and frame number, the same interaction Explore got in #8342.

The pressable readout is not an Explore component — `PlayheadTime` lives in `@fiftyone/playback` and `TimelineControls` renders it unconditionally, so Annotate has been mounting it all along. It just took the early return:

```tsx
if (!canToggle) {
  return readout;   // plain <Text>, no button
}
```

`canToggle` is `resolvedMode.kind !== "duration"`, and Annotate's provider was `<PlaybackProvider snapToFrameOnSettle>` with no `mode` at all, which defaults to `duration`. No frame domain to switch into, so nothing to toggle between.

The fix passes sequence mode built from the frame rate the surface has already resolved. Two things Explore needs that this doesn't:

- **No `duration` fallback.** `useAnnotatePrerequisites` blocks the surface outright unless fps is finite and positive, so `status === "ready"` guarantees one. Explore's fps is optional, hence its ternary.
- **No remount key.** Explore keys its provider because `mode` is frozen at mount and its fps can change underneath it. Annotate gates on `prerequisites.status` and `resolution.status` before it ever reaches the provider, so it mounts once on resolved values — and remounting here would tear down the registrars, the Lighter bridge, and any open point session.

`defaultDisplay="duration"` keeps the display opening on timecode; frames stay opt-in, matching Explore.

### One behavior change rides along

`mode` feeds the engine, not just the display, but only two places read it:

- `resolvedStepInterval` — the fallback used when no stream publishes a step: `stepInterval ?? (sequence ? 1/fps : 1/30)`
- the `absolute` branch of `lastFrameStart`, which `sequence` and `duration` both skip

So the delta is that fallback going from a hardcoded 1/30 to the true 1/fps. A correction for 29.97fps content, and a no-op wherever a stream already publishes its native step. Worth a reviewer's eye — I did not audit which Annotate streams publish one.

## 🧪 How is this patch tested? If it is not, please explain why.

- `yarn vitest run --no-coverage packages/video-annotation packages/playback/src/views/Playhead` — 39 files, 351 tests, all passing.
- `yarn typecheck` — 1135 errors, identical to the pre-change baseline on `feat/videoExploreTimeline` (verified by stashing and re-running). No errors in `video-annotation`.
- No new tests. The toggle's own behavior is already covered in `@fiftyone/playback`; this change only supplies the `mode` that enables it.

**Not verified in the running App.** The step-interval change above is a real runtime delta the unit tests don't exercise. Someone should click the readout on a 29.97fps sample in Annotate before this merges.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

The Annotate tab's timeline readout can now be clicked to switch between timecode and frame number, matching the Explore tab.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Video annotation playback now displays the sequence duration by default.
  * Timeline navigation uses the resolved frame rate for more accurate positioning.
  * Playback continues to snap to the nearest frame when navigation settles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->