### PR TITLE
Added docs for the new fo skill editor

### DIFF
--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -326,11 +326,76 @@ agent exactly how to perform a task, step by step.
    :alt: fiftyone-agent-skills
    :align: center
 
+Open any skill to read its full definition: the description that tells the
+Agent when to use it, and the step-by-step instructions it follows. Built-in
+skills are read-only, so you can always see exactly what the Agent was told
+to do.
+
+Use the toggle on each skill to control which ones the Agent may use. Turning
+a skill off removes it from the Agent's options without deleting anything.
+
+.. _enterprise-agent-skills-editing:
+
+Creating and editing skills
+___________________________
+
+Admins can extend the Agent with their own skills, directly from the settings
+panel. No plugin packaging or deployment step is required.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/skill_editor.webp
+   :alt: fiftyone-agent-skill-editor
+   :align: center
+
+Click **Create skill** to write a new one. Every skill needs three things:
+
+- **Name**: lowercase and dash-separated, e.g. ``triage-blurry-images``
+- **Description**: when the Agent should reach for this skill. This is the
+  only thing the Agent sees when choosing between skills, so write it as
+  *when to use this*, not *what this is*
+- **Instructions**: the workflow itself, in Markdown, covering what to check
+  first, which operators to call, and the steps to follow
+
+To adapt a built-in skill, open it and click **Duplicate**. This gives you an
+editable copy, leaving the original untouched. The copy needs its own name and
+its own description: two skills that describe themselves the same way make the
+Agent's choice between them arbitrary.
+
+Once your copy is saved, switch the built-in skill **off** using its toggle.
+The Agent then uses your version instead, and you keep the original in place
+to turn back on or duplicate again later.
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/skills.webp
+   :alt: fiftyone-agent-skill-toggle
+   :align: center
+
 .. note::
 
-    You can also build and add your own custom skills to extend the agent's
-    capabilities. See :ref:`Developing skills <agents-developing>` for full
-    instructions.
+    Custom skills are stored as a plugin in your deployment, so they can be
+    downloaded and shared like any other plugin. See
+    :ref:`Developing skills <agents-developing>` if you would rather author
+    them as files.
+
+.. _enterprise-agent-skills-ask:
+
+Asking the Agent to write a skill
+_________________________________
+
+You can also ask the Agent to write or improve a skill for you, for example
+*"turn the steps we just worked through into a skill"* or *"add a validation
+step to my triage skill"*.
+
+
+.. image:: https://cdn.voxel51.com/voxel-agent/enterprise/skill_agent_authored.webp
+   :alt: fiftyone-agent-skill-toggle
+   :align: center
+
+The Agent never writes a skill on its own. It proposes the change in a review
+card showing exactly what would be added and removed, line by line, against
+the current version. Nothing is saved until you click **Approve**, and
+rejecting leaves the skill exactly as it was.
+
+Built-in skills stay protected here too: if you ask the Agent to change one,
+it will propose a copy instead of modifying the original.
 
 .. customanimatedcta::
     :button_text: Browse Enterprise Skills

--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -204,6 +204,34 @@ in every conversation, at three scopes:
 
 Configure instructions from the Agent's settings panel.
 
+.. _enterprise-agent-knowledge:
+
+Grounding answers in the documentation
+______________________________________
+
+The Agent can ground its answers in the live FiftyOne documentation. Before
+answering a question about the SDK, an operator, or an API, it searches a
+knowledge base that stays continuously in sync with the docs, so answers
+reflect the current release and cite the sources they came from.
+
+This is powered by a `Kapa <https://www.kapa.ai>`_ knowledge base hosted by
+Voxel51. To enable it, set the ``KAPA_API_KEY`` secret in your deployment.
+Your customer success contact can provide the key.
+
+.. code-block:: shell
+
+    export KAPA_API_KEY=...
+
+The lookup is optional, and the Agent works without it. We strongly recommend
+enabling it: without the key, FiftyOne questions are answered from the model's
+general knowledge, which is not tied to your version and drifts as the product
+evolves.
+
+.. note::
+
+    No dataset content is sent to the knowledge base. Only the search query
+    the Agent formulates is transmitted.
+
 .. _enterprise-agent-using:
 
 Using the agent

--- a/docs/source/enterprise/agent.rst
+++ b/docs/source/enterprise/agent.rst
@@ -364,6 +364,10 @@ Once your copy is saved, switch the built-in skill **off** using its toggle.
 The Agent then uses your version instead, and you keep the original in place
 to turn back on or duplicate again later.
 
+To remove a custom skill for good, open it and click **Delete**. You will be
+asked to confirm, and the skill is gone for everyone in the deployment.
+Built-in skills cannot be deleted, only switched off.
+
 .. image:: https://cdn.voxel51.com/voxel-agent/enterprise/skills.webp
    :alt: fiftyone-agent-skill-toggle
    :align: center
@@ -372,8 +376,8 @@ to turn back on or duplicate again later.
 
     Custom skills are stored as a plugin in your deployment, so they can be
     downloaded and shared like any other plugin. See
-    :ref:`Developing skills <agents-developing>` if you would rather author
-    them as files.
+    :ref:`Writing a skill <developing-skills-authoring>` if you would rather
+    author them as files.
 
 .. _enterprise-agent-skills-ask:
 
@@ -386,7 +390,7 @@ step to my triage skill"*.
 
 
 .. image:: https://cdn.voxel51.com/voxel-agent/enterprise/skill_agent_authored.webp
-   :alt: fiftyone-agent-skill-toggle
+   :alt: fiftyone-agent-skill-review-card
    :align: center
 
 The Agent never writes a skill on its own. It proposes the change in a review


### PR DESCRIPTION
## 🔗 Related Issues

Related to voxel51/fiftyone-teams#4014

## 📋 What changes are proposed in this pull request?

Adds documentation for custom FiftyOne Agent skills.

* Admins can create, edit, disable, and delete custom skills.
* Built-in skills cannot be modified, but they can be duplicated and customized.
* Documents how the Agent can propose a skill for admin review.
* Explains how custom skills use the existing plugin system.

This PR documents the feature introduced in voxel51/fiftyone-teams#4014.

## 🧪 How is this patch tested? If it is not, please explain why.

* Docs build locally without errors.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No. You can skip the rest of this section.
* [x] Yes. Give a description of this change to be included in the release
  notes for FiftyOne users.

**FiftyOne Agent custom skills**: Admins can now create and manage custom Agent skills. Built-in skills can also be duplicated and customized.

### What areas of FiftyOne does this PR affect?

* [ ] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [ ] Core: Core `fiftyone` Python library changes
* [x] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4015
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on grounding Agent answers in synchronized documentation through a Kapa knowledge base.
  * Clarified that built-in skills are read-only and can be enabled or disabled individually.
  * Added instructions for creating, editing, duplicating, and managing custom skills.
  * Documented how to ask the Agent to propose skill changes for review before saving.
  * Explained that custom skills are stored as plugins and built-in skills remain protected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->