### PR TITLE
Cloud push plugin (2/3): panel, push operator and progress sinks

### DIFF
--- a/local-plugins/cloud/__init__.py
+++ b/local-plugins/cloud/__init__.py
@@ -1,0 +1,68 @@
+"""
+FiftyOne Cloud plugin: the OSS → cloud conversion path without leaving the
+App.
+
+A hybrid plugin. ``CloudPanel`` (``panel.py``) is the surface — a React view
+over Python methods that are all sub-second — and ``PushToCloud``
+(``operators.py``) owns every slow thing behind it: the dataset scan, the
+preview, and the upload itself. ``CloudPushSubscription`` republishes the
+``cloud_push`` execution store over SSE so progress survives a closed panel.
+
+Everything cloud-facing lives in the plugin-local ``engine`` package, which
+has no fiftyone imports; this package and ``cli.py`` are the two shells
+around it.
+"""
+
+from .constants import (
+    ALREADY_RUNNING_MESSAGE,
+    API_URL_ENV_VAR,
+    AUTH_URL_ENV_VAR,
+    AUTO_CONFIRM_FILE_LIMIT,
+    DEFAULT_API_URL,
+    DEFAULT_AUTH_URL,
+    HEARTBEAT_STALE_S,
+    NOT_PAIRED_MESSAGE,
+    PLAN_CACHE_TTL_S,
+    PUSH_KEY,
+    REJECTED_PREVIEW_LIMIT,
+    RUNNING_GUARD_S,
+    STALLED_MESSAGE,
+    STORE_NAME,
+    TERMINAL_SURFACE_S,
+    TERMINAL_TTL_S,
+    ConnectionStatus,
+    ErrorKind,
+    ParamKey,
+    PollStatusValue,
+    PushMode,
+    PushStatus,
+    PushTarget,
+)
+from .models import (
+    ConnectionData,
+    ErrorInfo,
+    OutcomeInfo,
+    PairingDisplay,
+    PreviewInfo,
+    PushData,
+    RejectionInfo,
+    ResumableInfo,
+)
+from .operators import CloudPushSubscription, OpenCloudPanel, PushToCloud
+from .panel import CloudPanel
+from .plan_cache import PLAN_CACHE, PlanCache
+from .progress import (
+    CompositeSink,
+    PanelDataSink,
+    ProgressSink,
+    PushWorker,
+    StoreSink,
+    Throttle,
+)
+
+
+def register(plugin):
+    plugin.register(CloudPanel)
+    plugin.register(PushToCloud)
+    plugin.register(CloudPushSubscription)
+    plugin.register(OpenCloudPanel)

--- a/local-plugins/cloud/constants.py
+++ b/local-plugins/cloud/constants.py
@@ -1,0 +1,170 @@
+"""
+Names and tunables shared by the panel, the operators, and the progress
+sinks. Kept in its own module so every shell can import them without
+importing the plugin package root, which registers operators.
+"""
+
+from enum import Enum
+
+# --- URL resolution -------------------------------------------------------
+
+API_URL_ENV_VAR = "FIFTYONE_CLOUD_API_URL"
+AUTH_URL_ENV_VAR = "FIFTYONE_CLOUD_AUTH_URL"
+
+# PROPOSAL (open question 1): production hostnames are not settled, so the
+# defaults ship empty and the panel auto-expands "Advanced" when neither the
+# environment nor a stored profile supplies a URL. When the hostnames land,
+# the candidates are "https://api.fiftyone.ai" and
+# "https://auth.fiftyone.ai/cas/api" (CAS bases carry their path prefix).
+DEFAULT_API_URL = ""
+DEFAULT_AUTH_URL = ""
+
+# --- Execution store ------------------------------------------------------
+
+STORE_NAME = "cloud_push"
+PUSH_KEY = "push"
+
+# A stored ``running`` snapshot older than this means the worker stopped
+# reporting; ``on_load`` surfaces it as failed rather than as live progress.
+HEARTBEAT_STALE_S = 60
+
+# A fresh ``running`` snapshot within this window refuses a second push.
+RUNNING_GUARD_S = 30
+
+# How long a terminal snapshot keeps being shown to a reopened panel.
+TERMINAL_SURFACE_S = 3600
+
+# TTL written on the store key once the push reaches a terminal state.
+TERMINAL_TTL_S = 86400
+
+# --- Push mechanics -------------------------------------------------------
+
+# Only this many rejection reasons are carried in the outcome; the full list
+# is unbounded and the store value has a 16 MB cap.
+REJECTED_PREVIEW_LIMIT = 20
+
+# A built plan is parked here between the preview and the confirm.
+PLAN_CACHE_TTL_S = 600
+
+# Live channel: at most one panel-data patch per this interval, unless the
+# status or stage changed or the snapshot is terminal.
+PANEL_THROTTLE_S = 0.25
+
+# Durable channel: at most one store write per this interval, same escapes.
+STORE_THROTTLE_S = 2.0
+
+# The generator drains the worker's event queue on this cadence.
+QUEUE_POLL_S = 0.25
+
+# A preview with no missing media, fewer files than this, and no resumable
+# state skips the confirm step in the App.
+AUTO_CONFIRM_FILE_LIMIT = 100
+
+# --- Operator / panel URIs ------------------------------------------------
+
+PLUGIN_NAME = "@voxel51/cloud"
+PANEL_NAME = "cloud_panel"
+PANEL_LABEL = "FiftyOne Cloud"
+PUSH_OPERATOR_NAME = "push_to_cloud"
+SUBSCRIPTION_OPERATOR_NAME = "cloud_push_subscription"
+OPEN_PANEL_OPERATOR_NAME = "open_cloud_panel"
+
+PUSH_OPERATOR_URI = f"{PLUGIN_NAME}/{PUSH_OPERATOR_NAME}"
+SUBSCRIPTION_OPERATOR_URI = f"{PLUGIN_NAME}/{SUBSCRIPTION_OPERATOR_NAME}"
+
+# The React component registered by the JS bundle.
+PANEL_COMPONENT = "CloudPanelView"
+
+
+class ParamKey(str, Enum):
+    """Keys the App sends into panel methods and the push operator.
+
+    Panel-method params arrive at the top level of ``ctx.params`` alongside
+    ``panel_id`` and ``panel_state``.
+    """
+
+    API_URL = "api_url"
+    AUTH_URL = "auth_url"
+    DEVICE_CODE = "device_code"
+    MODE = "mode"
+    TARGET = "target"
+    DATASET_NAME = "dataset_name"
+    FRESH = "fresh"
+    PLAN_TOKEN = "plan_token"
+    PANEL_ID = "panel_id"
+
+
+class PanelDataKey(str, Enum):
+    """Top-level keys of panel ``data``. ``patch_panel_data`` replaces a whole
+    top-level key, so every patch under one of these is a complete object."""
+
+    CONNECTION = "connection"
+    PUSH = "push"
+
+
+class PushMode(str, Enum):
+    """Which half of ``push_to_cloud`` the caller wants."""
+
+    PREVIEW = "preview"
+    PUSH = "push"
+
+
+class PushTarget(str, Enum):
+    DATASET = "dataset"
+    VIEW = "view"
+
+
+class ConnectionStatus(str, Enum):
+    DISCONNECTED = "disconnected"
+    PAIRING = "pairing"
+    CONNECTED = "connected"
+
+
+class PushStatus(str, Enum):
+    IDLE = "idle"
+    PLANNING = "planning"
+    PREVIEW = "preview"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Terminal statuses get a TTL on the store key and always write
+        through the throttles."""
+        return self in (PushStatus.DONE, PushStatus.FAILED)
+
+
+class PollStatusValue(str, Enum):
+    """What ``poll_pairing`` reports back to the browser. A superset of the
+    engine's ``PollStatus``: the two transport faults the panel method
+    catches rather than raises are statuses here."""
+
+    PENDING = "pending"
+    SLOW_DOWN = "slow_down"
+    ISSUED = "issued"
+    EXPIRED = "expired"
+    DENIED = "denied"
+    REFUSED = "refused"
+    UNAVAILABLE = "unavailable"
+
+
+class ErrorKind(str, Enum):
+    """The taxonomy the App renders copy from. One kind per engine error
+    class; anything unmapped is ``UNKNOWN``."""
+
+    UNAVAILABLE = "unavailable"
+    REFUSED = "refused"
+    SESSION_EXPIRED = "session_expired"
+    KEY_REFUSED = "key_refused"
+    NOT_PAIRED = "not_paired"
+    PAIRING_EXPIRED = "pairing_expired"
+    PAIRING_DENIED = "pairing_denied"
+    UNKNOWN = "unknown"
+
+
+# Messages the server does not own. A refusal carries the server's own
+# message verbatim, so it has no entry here.
+STALLED_MESSAGE = "The upload stopped reporting progress; run again to resume"
+ALREADY_RUNNING_MESSAGE = "An upload of this dataset is already running"
+NOT_PAIRED_MESSAGE = "This machine is not connected to FiftyOne Cloud"

--- a/local-plugins/cloud/fiftyone.yml
+++ b/local-plugins/cloud/fiftyone.yml
@@ -1,0 +1,19 @@
+name: "@voxel51/cloud"
+version: "0.1.0"
+description: >
+  Push local datasets to FiftyOne Cloud: device pairing, resumable
+  direct-to-store media upload, and idempotent metadata ingest.
+fiftyone:
+  version: "*"
+author: Voxel51, Inc.
+license: Apache 2.0
+tags:
+  - cloud
+  - import-export
+js_bundle: ./js/dist/index.umd.js
+panels:
+  - cloud_panel
+operators:
+  - open_cloud_panel
+  - push_to_cloud
+  - cloud_push_subscription

--- a/local-plugins/cloud/models.py
+++ b/local-plugins/cloud/models.py
@@ -1,0 +1,571 @@
+"""
+The panel-data contract, typed.
+
+Panel ``data`` is write-only from Python and every ``patch_panel_data``
+replaces a whole top-level key, so each patch has to carry a complete
+object. These dataclasses are that object; ``asdict``-style serialization
+happens once, at the boundary, via :func:`to_payload`. Nothing outside this
+module should hand-build one of these dicts.
+
+The same ``push`` payload is what goes into the execution store, so the
+browser sees one shape whether it arrived over panel data or over SSE.
+"""
+
+import datetime
+import logging
+import os
+from dataclasses import dataclass, field, fields, is_dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from .constants import (
+    API_URL_ENV_VAR,
+    AUTH_URL_ENV_VAR,
+    DEFAULT_API_URL,
+    DEFAULT_AUTH_URL,
+    HEARTBEAT_STALE_S,
+    REJECTED_PREVIEW_LIMIT,
+    RUNNING_GUARD_S,
+    STALLED_MESSAGE,
+    TERMINAL_SURFACE_S,
+    ConnectionStatus,
+    ErrorKind,
+    PushStatus,
+)
+from .engine import (
+    CloudUnavailableError,
+    KeyRefusedError,
+    NotPairedError,
+    PairingDeniedError,
+    PairingExpiredError,
+    PushStage,
+    RefusedError,
+    SessionExpiredError,
+)
+
+logger = logging.getLogger(__name__)
+
+#: One entry per engine error class. ``CredentialExpiredError`` is
+#: deliberately absent: it is an internal retry signal, and if it ever
+#: escapes the pusher the user has nothing to do about it beyond re-running,
+#: which is what UNKNOWN already says.
+_ERROR_KINDS = (
+    (CloudUnavailableError, ErrorKind.UNAVAILABLE),
+    (SessionExpiredError, ErrorKind.SESSION_EXPIRED),
+    (KeyRefusedError, ErrorKind.KEY_REFUSED),
+    (NotPairedError, ErrorKind.NOT_PAIRED),
+    (PairingExpiredError, ErrorKind.PAIRING_EXPIRED),
+    (PairingDeniedError, ErrorKind.PAIRING_DENIED),
+    (RefusedError, ErrorKind.REFUSED),
+)
+
+
+def utc_now() -> datetime.datetime:
+    """The one clock. Tests substitute by monkeypatching this symbol."""
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def to_payload(model: Any) -> Dict[str, Any]:
+    """Serializes a model to the App's wire shape.
+
+    Drops ``None`` fields (the contract marks them optional rather than
+    nullable), renders ``datetime`` as ISO 8601, and unwraps ``str`` enums
+    to their values. Must be applied to every object handed to
+    ``patch_panel_data`` or ``store.set``.
+    """
+    payload = _encode(model)
+    if not isinstance(payload, dict):
+        raise TypeError(f"{type(model).__name__} is not a payload model")
+    return payload
+
+
+def _encode(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        encoded = {}
+        for spec in fields(value):
+            item = getattr(value, spec.name)
+            if item is None:
+                continue
+            encoded[spec.name] = _encode(item)
+        return encoded
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime.datetime):
+        return value.isoformat()
+    if isinstance(value, (list, tuple)):
+        return [_encode(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _encode(item) for key, item in value.items()}
+    return value
+
+
+def iso(value: Optional[datetime.datetime]) -> Optional[str]:
+    """ISO 8601, or ``None`` passthrough."""
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+def parse_iso(value: Optional[str]) -> Optional[datetime.datetime]:
+    """Reads an ISO 8601 string back off a store snapshot. Returns ``None``
+    on absent or unparseable input rather than raising — a corrupt store
+    value must not break ``on_load``."""
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def age_seconds(
+    value: Optional[str], now: Optional[datetime.datetime] = None
+) -> Optional[float]:
+    """Seconds since an ISO 8601 timestamp; ``None`` when unparseable.
+
+    Drives every staleness rule (``HEARTBEAT_STALE_S``, ``RUNNING_GUARD_S``,
+    ``TERMINAL_SURFACE_S``).
+    """
+    stamped = parse_iso(value)
+    if stamped is None:
+        return None
+    return ((now or utc_now()) - stamped).total_seconds()
+
+
+# --- Errors ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ErrorInfo:
+    kind: ErrorKind
+    message: str
+
+
+def error_from(exception: BaseException) -> ErrorInfo:
+    """Maps an engine exception onto the App's error taxonomy.
+
+    The message is ``str(exception)``; the App supplies the user-facing copy
+    for every kind except REFUSED, which it renders verbatim.
+    """
+    for error_class, kind in _ERROR_KINDS:
+        if isinstance(exception, error_class):
+            return ErrorInfo(kind=kind, message=str(exception))
+    return ErrorInfo(kind=ErrorKind.UNKNOWN, message=str(exception))
+
+
+# --- Connection -----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PairingDisplay:
+    """Everything the Pairing screen shows. Deliberately without
+    ``device_code``: panel data is workspace-persisted and echoed on every
+    event, so the secret half of the pairing lives only in a module-private
+    jotai atom in the browser."""
+
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    expires_at: datetime.datetime
+    interval: int
+
+
+def resolve_urls(profile: Optional[Any]) -> "tuple[str, str]":
+    """``(api_url, auth_url)`` by precedence: environment
+    (``FIFTYONE_CLOUD_API_URL`` / ``FIFTYONE_CLOUD_AUTH_URL``), then the
+    stored profile, then ``DEFAULT_API_URL`` / ``DEFAULT_AUTH_URL``.
+
+    Runs against a keyless profile too, which is the whole point of keeping
+    one after Disconnect: the URLs survive and the form stays prefilled.
+    Both are returned right-stripped of "/".
+    """
+    api_url = (
+        os.environ.get(API_URL_ENV_VAR)
+        or (profile.api_url if profile is not None else "")
+        or DEFAULT_API_URL
+    )
+    auth_url = (
+        os.environ.get(AUTH_URL_ENV_VAR)
+        or (profile.auth_url if profile is not None else "")
+        or DEFAULT_AUTH_URL
+    )
+    return api_url.rstrip("/"), auth_url.rstrip("/")
+
+
+@dataclass(frozen=True)
+class ConnectionData:
+    """``data.connection``.
+
+    Connected means a stored profile that carries an ``api_key``. A keyless
+    profile is disconnected-with-known-URLs, which is what makes Disconnect
+    non-destructive to the prefill chain.
+    """
+
+    status: ConnectionStatus
+    api_url: str
+    auth_url: str
+    key_scope: Optional[str] = None
+    key_expires_at: Optional[datetime.datetime] = None
+    pairing: Optional[PairingDisplay] = None
+    error: Optional[ErrorInfo] = None
+
+
+def connection_from_profile(
+    profile: Optional[Any],
+    api_url: str,
+    auth_url: str,
+    error: Optional[ErrorInfo] = None,
+) -> ConnectionData:
+    """Builds ``ConnectionData`` from a (possibly absent, possibly keyless)
+    ``CloudProfile`` plus the resolved URLs. Status is CONNECTED iff the
+    profile exists and has an ``api_key``."""
+    connected = profile is not None and bool(profile.api_key)
+    return ConnectionData(
+        status=(
+            ConnectionStatus.CONNECTED
+            if connected
+            else ConnectionStatus.DISCONNECTED
+        ),
+        api_url=api_url,
+        auth_url=auth_url,
+        key_scope=profile.key_scope if connected else None,
+        key_expires_at=profile.key_expires_at if connected else None,
+        error=error,
+    )
+
+
+# --- Push -----------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreviewInfo:
+    samples: int
+    files: int
+    total_bytes: int
+    missing: int
+
+
+@dataclass(frozen=True)
+class ResumableInfo:
+    """Present only when a push-state file exists for
+    ``(api_url, cloud dataset_name)``."""
+
+    uploaded: int
+    total: int
+
+
+@dataclass(frozen=True)
+class RejectionInfo:
+    index: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class OutcomeInfo:
+    dataset: str
+    samples: int
+    uploaded: int
+    skipped_uploads: int
+    missing_files: int
+    accepted: int
+    rejected_count: int
+    shortfall: int
+    rejected: List[RejectionInfo] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class PushData:
+    """``data.push`` and the execution-store value, one shape.
+
+    Every patch carries the whole object — there is no partial update — so
+    builders below always start from a complete prior snapshot or from
+    :func:`idle_push`.
+    """
+
+    status: PushStatus
+    updated_at: datetime.datetime
+    local_dataset: str
+    done: int = 0
+    total: int = 0
+    dataset_name: Optional[str] = None
+    stage: Optional[PushStage] = None
+    detail: Optional[str] = None
+    plan_token: Optional[str] = None
+    preview: Optional[PreviewInfo] = None
+    resumable: Optional[ResumableInfo] = None
+    outcome: Optional[OutcomeInfo] = None
+    error: Optional[ErrorInfo] = None
+
+
+def idle_push(local_dataset: str) -> PushData:
+    """The zero value: status IDLE, counters at 0, stamped now."""
+    return PushData(
+        status=PushStatus.IDLE,
+        updated_at=utc_now(),
+        local_dataset=local_dataset,
+    )
+
+
+def planning_push(local_dataset: str, total: int) -> PushData:
+    """Emitted first in both operator modes so the App shows a spinner
+    before the (potentially minutes-long) dataset scan starts. ``total`` is
+    the sample count, used only for the "scanning N samples" line."""
+    return PushData(
+        status=PushStatus.PLANNING,
+        updated_at=utc_now(),
+        local_dataset=local_dataset,
+        total=total,
+    )
+
+
+def preview_push(
+    local_dataset: str,
+    dataset_name: str,
+    plan_token: str,
+    preview: PreviewInfo,
+    resumable: Optional[ResumableInfo],
+) -> PushData:
+    """The end of ``mode="preview"``: the plan is parked under
+    ``plan_token`` and these are the numbers the App decides on."""
+    return PushData(
+        status=PushStatus.PREVIEW,
+        updated_at=utc_now(),
+        local_dataset=local_dataset,
+        dataset_name=dataset_name,
+        total=preview.files,
+        plan_token=plan_token,
+        preview=preview,
+        resumable=resumable,
+    )
+
+
+def running_push(
+    local_dataset: str,
+    dataset_name: str,
+    stage: PushStage,
+    done: int,
+    total: int,
+    detail: str = "",
+) -> PushData:
+    """One progress tick. Built from a ``PushEvent`` by
+    :func:`push_from_event`, and directly for the initial 0-of-N snapshot
+    the operator emits right after the worker starts (``Pusher`` is silent
+    until the first file completes, so without it the bar has no zero)."""
+    return PushData(
+        status=PushStatus.RUNNING,
+        updated_at=utc_now(),
+        local_dataset=local_dataset,
+        dataset_name=dataset_name,
+        stage=stage,
+        done=done,
+        total=total,
+        detail=detail or None,
+    )
+
+
+def push_from_event(
+    event: Any, local_dataset: str, dataset_name: str
+) -> PushData:
+    """``PushEvent`` -> running snapshot. Used by both sinks so the live and
+    durable channels never disagree about a tick."""
+    return running_push(
+        local_dataset=local_dataset,
+        dataset_name=dataset_name,
+        stage=event.stage,
+        done=event.done,
+        total=event.total,
+        detail=event.detail,
+    )
+
+
+def done_push(local_dataset: str, dataset_name: str, outcome: Any) -> PushData:
+    """Terminal success. Caps ``rejected`` at ``REJECTED_PREVIEW_LIMIT``
+    while keeping the true ``rejected_count`` — the store value has a 16 MB
+    cap and a large push can reject thousands."""
+    rejected = list(outcome.rejected)
+    return PushData(
+        status=PushStatus.DONE,
+        updated_at=utc_now(),
+        local_dataset=local_dataset,
+        dataset_name=dataset_name,
+        done=outcome.accepted,
+        total=outcome.samples,
+        outcome=OutcomeInfo(
+            dataset=outcome.dataset,
+            samples=outcome.samples,
+            uploaded=outcome.uploaded,
+            skipped_uploads=outcome.skipped_uploads,
+            missing_files=outcome.missing_files,
+            accepted=outcome.accepted,
+            rejected_count=len(rejected),
+            shortfall=outcome.shortfall,
+            rejected=[
+                RejectionInfo(index=item.index, reason=item.reason)
+                for item in rejected[:REJECTED_PREVIEW_LIMIT]
+            ],
+        ),
+    )
+
+
+def failed_push(
+    local_dataset: str,
+    dataset_name: Optional[str],
+    error: ErrorInfo,
+) -> PushData:
+    """Terminal failure."""
+    return PushData(
+        status=PushStatus.FAILED,
+        updated_at=utc_now(),
+        local_dataset=local_dataset,
+        dataset_name=dataset_name,
+        error=error,
+    )
+
+
+def push_from_store(
+    value: Optional[Dict[str, Any]], local_dataset: str
+) -> PushData:
+    """What a reopened panel lands on, per the ``on_load`` staleness rules.
+
+    - no value, or a shape that will not parse -> :func:`idle_push`
+    - RUNNING and older than ``HEARTBEAT_STALE_S`` -> FAILED with
+      ``ErrorKind.UNKNOWN`` and ``STALLED_MESSAGE``
+    - RUNNING and fresh -> as-is (the panel lands on Running)
+    - DONE/FAILED within ``TERMINAL_SURFACE_S`` -> as-is
+    - any older terminal, or a non-terminal leftover -> :func:`idle_push`
+    """
+    status = _stored_status(value)
+    if status is None:
+        return idle_push(local_dataset)
+
+    age = age_seconds(value.get("updated_at"))
+    if age is None:
+        return idle_push(local_dataset)
+
+    if status is PushStatus.RUNNING:
+        if age > HEARTBEAT_STALE_S:
+            return failed_push(
+                local_dataset=value.get("local_dataset") or local_dataset,
+                dataset_name=value.get("dataset_name"),
+                error=ErrorInfo(
+                    kind=ErrorKind.UNKNOWN, message=STALLED_MESSAGE
+                ),
+            )
+        return _safe_rehydrate(value, local_dataset)
+
+    if status.is_terminal and age <= TERMINAL_SURFACE_S:
+        return _safe_rehydrate(value, local_dataset)
+
+    return idle_push(local_dataset)
+
+
+def _safe_rehydrate(value: Dict[str, Any], local_dataset: str) -> PushData:
+    """:func:`_rehydrate`, degrading to idle on anything it cannot read.
+
+    Only this plugin writes the store, so a snapshot that will not rebuild
+    means version drift — a nested object short a field, or a counter that
+    stopped being a number. Either way the panel opens on the upload form
+    rather than breaking ``on_load``.
+    """
+    try:
+        return _rehydrate(value, local_dataset)
+    except (TypeError, ValueError, KeyError):
+        logger.warning(
+            "cloud push: discarding an unreadable stored snapshot",
+            exc_info=True,
+        )
+        return idle_push(local_dataset)
+
+
+def is_running_guarded(value: Optional[Dict[str, Any]]) -> bool:
+    """True when the stored snapshot says RUNNING and is younger than
+    ``RUNNING_GUARD_S`` — the condition under which ``mode="push"`` refuses
+    with ``ALREADY_RUNNING_MESSAGE``."""
+    if _stored_status(value) is not PushStatus.RUNNING:
+        return False
+    age = age_seconds(value.get("updated_at"))
+    return age is not None and age <= RUNNING_GUARD_S
+
+
+def _stored_status(value: Optional[Dict[str, Any]]) -> Optional[PushStatus]:
+    """The status of a store snapshot, or ``None`` when there isn't one that
+    parses. Every caller treats an unreadable value as no value at all."""
+    if not isinstance(value, dict):
+        return None
+    try:
+        return PushStatus(value.get("status"))
+    except ValueError:
+        return None
+
+
+def _rehydrate(value: Dict[str, Any], local_dataset: str) -> PushData:
+    """Rebuilds a ``PushData`` from a stored payload.
+
+    Panel data is handed the typed model rather than the raw dict so a
+    snapshot written by an older plugin version cannot smuggle unknown keys
+    into the App's state machine.
+    """
+    return PushData(
+        status=PushStatus(value["status"]),
+        updated_at=parse_iso(value.get("updated_at")) or utc_now(),
+        local_dataset=value.get("local_dataset") or local_dataset,
+        done=int(value.get("done") or 0),
+        total=int(value.get("total") or 0),
+        dataset_name=value.get("dataset_name"),
+        stage=_optional(PushStage, value.get("stage")),
+        detail=value.get("detail"),
+        plan_token=value.get("plan_token"),
+        preview=_nested(PreviewInfo, value.get("preview")),
+        resumable=_nested(ResumableInfo, value.get("resumable")),
+        outcome=_outcome(value.get("outcome")),
+        error=_error(value.get("error")),
+    )
+
+
+def _optional(enum_class: Any, value: Any) -> Any:
+    if value is None:
+        return None
+    try:
+        return enum_class(value)
+    except ValueError:
+        return None
+
+
+def _nested(model_class: Any, value: Any) -> Any:
+    if not isinstance(value, dict):
+        return None
+    names = {spec.name for spec in fields(model_class)}
+    return model_class(**{k: v for k, v in value.items() if k in names})
+
+
+def _outcome(value: Any) -> Optional[OutcomeInfo]:
+    if not isinstance(value, dict):
+        return None
+    rejected = value.get("rejected") or []
+    return OutcomeInfo(
+        dataset=value.get("dataset", ""),
+        samples=int(value.get("samples") or 0),
+        uploaded=int(value.get("uploaded") or 0),
+        skipped_uploads=int(value.get("skipped_uploads") or 0),
+        missing_files=int(value.get("missing_files") or 0),
+        accepted=int(value.get("accepted") or 0),
+        rejected_count=int(value.get("rejected_count") or 0),
+        shortfall=int(value.get("shortfall") or 0),
+        rejected=[
+            RejectionInfo(
+                index=int(item.get("index", 0)), reason=item.get("reason", "")
+            )
+            for item in rejected
+            if isinstance(item, dict)
+        ],
+    )
+
+
+def _error(value: Any) -> Optional[ErrorInfo]:
+    if not isinstance(value, dict):
+        return None
+    kind = _optional(ErrorKind, value.get("kind")) or ErrorKind.UNKNOWN
+    return ErrorInfo(kind=kind, message=value.get("message", ""))

--- a/local-plugins/cloud/operators.py
+++ b/local-plugins/cloud/operators.py
@@ -1,0 +1,372 @@
+"""
+The operators behind the panel.
+
+``PushToCloud`` owns everything slow: it plans, it previews, and it pushes.
+It is a generator so its first snapshot streams to the browser before the
+dataset scan begins, and it is unlisted because the panel is the only
+caller. ``CloudPushSubscription`` re-exposes the ``cloud_push`` store over
+SSE so a reopened panel picks up an upload the request stream no longer
+covers. ``OpenCloudPanel`` is the one listed operator: the grid button.
+
+There is no ``cloud_login`` operator any more — the CLI's ``login`` covers
+the headless case and never went through it.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Iterator, Optional
+
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+
+from .constants import (
+    ALREADY_RUNNING_MESSAGE,
+    NOT_PAIRED_MESSAGE,
+    OPEN_PANEL_OPERATOR_NAME,
+    PANEL_NAME,
+    PUSH_KEY,
+    PUSH_OPERATOR_NAME,
+    STORE_NAME,
+    SUBSCRIPTION_OPERATOR_NAME,
+    ErrorKind,
+    PanelDataKey,
+    ParamKey,
+    PushMode,
+    PushTarget,
+)
+from .engine import (
+    CloudError,
+    Http,
+    ProfileStore,
+    PushStage,
+    PushStateStore,
+    build_push_plan,
+    run_push,
+)
+from .models import (
+    ErrorInfo,
+    PreviewInfo,
+    ResumableInfo,
+    connection_from_profile,
+    error_from,
+    failed_push,
+    is_running_guarded,
+    planning_push,
+    preview_push,
+    resolve_urls,
+    running_push,
+    to_payload,
+)
+from .plan_cache import PLAN_CACHE
+from .progress import CompositeSink, PanelDataSink, PushWorker, StoreSink
+
+
+@dataclass(frozen=True)
+class _Sinks:
+    """The two progress channels plus their fan-out.
+
+    Held together rather than rebuilt per call so the worker and the request
+    thread share one ``StoreSink`` — and therefore one throttle, so a
+    request-thread snapshot and a worker snapshot cannot both write the
+    store in the same tick.
+    """
+
+    panel: PanelDataSink
+    store: StoreSink
+    both: CompositeSink
+
+
+@dataclass(frozen=True)
+class _Request:
+    """One decoded invocation. Everything both modes need to know."""
+
+    mode: PushMode
+    target: PushTarget
+    local_dataset: str
+    dataset_name: str
+    fresh: bool
+    plan_token: Optional[str]
+    panel_id: Optional[str]
+
+
+class PushToCloud(foo.Operator):
+    """``@voxel51/cloud/push_to_cloud`` — unlisted, generator.
+
+    Every ``push`` status has exactly one producer: this operator, on its
+    request thread or on its worker thread. Nothing else writes
+    ``data.push`` or the store key except ``CloudPanel.on_load`` and
+    ``reset_push``.
+    """
+
+    @property
+    def config(self) -> foo.OperatorConfig:
+        return foo.OperatorConfig(
+            name=PUSH_OPERATOR_NAME,
+            label="Upload to FiftyOne Cloud",
+            unlisted=True,
+            execute_as_generator=True,
+        )
+
+    def execute(self, ctx) -> Iterator[Any]:
+        """Resolves the shared preconditions, then dispatches on ``mode``.
+
+        Both modes first require a paired profile; without one they emit a
+        FAILED push *and* a DISCONNECTED connection, so the panel drops
+        straight to the Connect screen instead of showing a dead upload
+        form.
+        """
+        request = _decode(ctx)
+        sinks = _build_sinks(ctx, request.panel_id)
+
+        profile = ProfileStore().load()
+        if profile is None or not profile.api_key:
+            yield from sinks.both.emit(
+                failed_push(
+                    request.local_dataset,
+                    request.dataset_name,
+                    ErrorInfo(
+                        kind=ErrorKind.NOT_PAIRED, message=NOT_PAIRED_MESSAGE
+                    ),
+                )
+            )
+            api_url, auth_url = resolve_urls(profile)
+            yield ctx.ops.patch_panel_data(
+                {
+                    PanelDataKey.CONNECTION.value: to_payload(
+                        connection_from_profile(profile, api_url, auth_url)
+                    )
+                },
+                panel_id=request.panel_id,
+            )
+            return
+
+        if request.mode is PushMode.PREVIEW:
+            yield from self._preview(ctx, request, sinks, profile)
+        else:
+            yield from self._push(ctx, request, sinks, profile)
+
+    def _preview(self, ctx, request, sinks, profile) -> Iterator[Any]:
+        """``mode="preview"`` — plan, price it, park the plan."""
+        samples = self._samples(ctx, request.target)
+
+        # Yielded before the scan starts: the scan is seconds to minutes and
+        # this is the only thing that puts a spinner on screen first.
+        yield from sinks.both.emit(
+            planning_push(request.local_dataset, _count(samples))
+        )
+
+        try:
+            plan = build_push_plan(samples)
+            state = PushStateStore(
+                profile.api_url, request.dataset_name
+            ).load()
+        except (CloudError, OSError) as error:
+            yield from sinks.both.emit(
+                failed_push(
+                    request.local_dataset,
+                    request.dataset_name,
+                    error_from(error),
+                )
+            )
+            return
+
+        resumable = None
+        if state is not None:
+            resumable = ResumableInfo(
+                uploaded=len(state.uploaded_keys), total=len(plan.media)
+            )
+
+        token = PLAN_CACHE.put(
+            plan, request.local_dataset, request.target.value
+        )
+        yield from sinks.both.emit(
+            preview_push(
+                local_dataset=request.local_dataset,
+                dataset_name=request.dataset_name,
+                plan_token=token,
+                preview=PreviewInfo(
+                    samples=len(plan.sample_docs),
+                    files=len(plan.media),
+                    total_bytes=plan.summary.total_bytes,
+                    missing=len(plan.missing),
+                ),
+                resumable=resumable,
+            )
+        )
+
+    def _push(self, ctx, request, sinks, profile) -> Iterator[Any]:
+        """``mode="push"`` — run the upload on a worker and bridge it."""
+        store = ctx.store(STORE_NAME)
+        if is_running_guarded(store.get(PUSH_KEY)):
+            yield from sinks.both.emit(
+                failed_push(
+                    request.local_dataset,
+                    request.dataset_name,
+                    ErrorInfo(
+                        kind=ErrorKind.REFUSED,
+                        message=ALREADY_RUNNING_MESSAGE,
+                    ),
+                )
+            )
+            return
+
+        plan = PLAN_CACHE.take(
+            request.plan_token, request.local_dataset, request.target.value
+        )
+        if plan is None:
+            # An expired or restarted-server token costs a rebuild, not an
+            # error; the preview the user approved is still what happens.
+            samples = self._samples(ctx, request.target)
+            yield from sinks.both.emit(
+                planning_push(request.local_dataset, _count(samples))
+            )
+            try:
+                plan = build_push_plan(samples)
+            except (CloudError, OSError) as error:
+                yield from sinks.both.emit(
+                    failed_push(
+                        request.local_dataset,
+                        request.dataset_name,
+                        error_from(error),
+                    )
+                )
+                return
+
+        # ``Pusher`` says nothing until the first file completes, so without
+        # this the bar has no zero and the panel looks hung.
+        #
+        # Emitted *before* the worker starts, which is what makes the shared
+        # StoreSink safe: this is the request thread's last store write, so
+        # it can never land on top of the worker's terminal one. A trivially
+        # short push — an empty plan, or a failure at session open — would
+        # otherwise leave the store stuck on ``running`` forever, and the
+        # next ``on_load`` would report a finished upload as stalled.
+        yield from sinks.both.emit(
+            running_push(
+                local_dataset=request.local_dataset,
+                dataset_name=request.dataset_name,
+                stage=PushStage.UPLOADING,
+                done=0,
+                total=len(plan.media),
+            )
+        )
+
+        worker = PushWorker(
+            run=lambda on_progress: run_push(
+                profile,
+                request.dataset_name,
+                (),
+                Http(),
+                on_progress=on_progress,
+                fresh=request.fresh,
+                plan=plan,
+            ),
+            store_sink=sinks.store,
+            local_dataset=request.local_dataset,
+            dataset_name=request.dataset_name,
+        )
+        worker.start()
+
+        # Panel data only from here: the worker owns the store.
+        yield from worker.drain(sinks.panel)
+
+        terminal = worker.snapshot()
+        if terminal is not None:
+            yield from sinks.panel.emit(terminal)
+
+    def _samples(self, ctx, target: PushTarget) -> Any:
+        """``ctx.view`` for ``target="view"``, else ``ctx.dataset``."""
+        if target is PushTarget.VIEW:
+            return ctx.view
+        return ctx.dataset
+
+
+class CloudPushSubscription(foo.SseOperator):
+    """``@voxel51/cloud/cloud_push_subscription``.
+
+    The recovery channel. The App's ``/operators/subscribe-execution-store``
+    endpoint drives this; its initial sync replays the current key, so a
+    panel opened mid-upload sees the latest snapshot without polling.
+    """
+
+    @property
+    def subscription_config(self) -> foo.SseOperatorConfig:
+        return foo.SseOperatorConfig(
+            name=SUBSCRIPTION_OPERATOR_NAME,
+            label="Cloud push subscription",
+            store_name=STORE_NAME,
+        )
+
+
+class OpenCloudPanel(foo.Operator):
+    """``@voxel51/cloud/open_cloud_panel`` — the only listed operator."""
+
+    @property
+    def config(self) -> foo.OperatorConfig:
+        return foo.OperatorConfig(
+            name=OPEN_PANEL_OPERATOR_NAME, label="FiftyOne Cloud"
+        )
+
+    def resolve_placement(self, ctx) -> types.Placement:
+        return types.Placement(
+            types.Places.SAMPLES_GRID_SECONDARY_ACTIONS,
+            types.Button(
+                label="FiftyOne Cloud",
+                icon="cloud_upload",
+                prompt=False,
+            ),
+        )
+
+    def execute(self, ctx) -> None:
+        ctx.ops.open_panel(PANEL_NAME)
+
+
+def _decode(ctx) -> _Request:
+    """Panel-method and operator params both arrive at the top level of
+    ``ctx.params``.
+
+    Never raises. This operator is the sole producer of every ``push``
+    status, so a decode that threw would leave the panel showing whatever
+    card it was on with nothing to move it off; the safe reading of an
+    unrecognized value is the one that only ever previews.
+    """
+    local_dataset = getattr(ctx.dataset, "name", "") or ""
+    return _Request(
+        mode=_enum(
+            PushMode, ctx.params.get(ParamKey.MODE.value), PushMode.PREVIEW
+        ),
+        target=_enum(
+            PushTarget,
+            ctx.params.get(ParamKey.TARGET.value),
+            PushTarget.DATASET,
+        ),
+        local_dataset=local_dataset,
+        dataset_name=(
+            ctx.params.get(ParamKey.DATASET_NAME.value) or local_dataset
+        ),
+        fresh=bool(ctx.params.get(ParamKey.FRESH.value, False)),
+        plan_token=ctx.params.get(ParamKey.PLAN_TOKEN.value),
+        panel_id=ctx.params.get(ParamKey.PANEL_ID.value),
+    )
+
+
+def _enum(enum_class, value, fallback):
+    """The enum member for ``value``, or ``fallback`` when it is absent or
+    not one the plugin knows."""
+    if value is None:
+        return fallback
+    try:
+        return enum_class(value)
+    except ValueError:
+        return fallback
+
+
+def _build_sinks(ctx, panel_id: Optional[str]) -> _Sinks:
+    panel = PanelDataSink(ctx, panel_id)
+    store = StoreSink(ctx.store(STORE_NAME))
+    return _Sinks(panel=panel, store=store, both=CompositeSink([panel, store]))
+
+
+def _count(samples) -> int:
+    if samples is None:
+        return 0
+    return len(samples)

--- a/local-plugins/cloud/panel.py
+++ b/local-plugins/cloud/panel.py
@@ -1,0 +1,395 @@
+"""
+The App-side shell: a hybrid panel whose Python half holds only sub-second
+work.
+
+Everything that scans a dataset lives in ``push_to_cloud`` instead, because
+a panel method's return value reaches the browser only when it returns —
+a long method is a frozen panel. Pairing is likewise non-blocking: this
+class hands the codes back immediately and the browser polls, rather than
+holding one HTTP stream open for the pairing TTL.
+
+``device_code`` is never written into panel data. Panel state is
+workspace-persisted and panel data is echoed on every event; the secret
+half of the pairing lives only in a module-private atom in the browser and
+comes back as a parameter on each poll.
+"""
+
+import datetime
+from typing import Any, Dict, Optional
+
+import fiftyone.constants as foc
+import fiftyone.operators as foo
+import fiftyone.operators.types as types
+
+from .constants import (
+    PANEL_COMPONENT,
+    PANEL_LABEL,
+    PANEL_NAME,
+    PUSH_KEY,
+    STORE_NAME,
+    ConnectionStatus,
+    ErrorKind,
+    PanelDataKey,
+    ParamKey,
+    PollStatusValue,
+)
+from .engine import (
+    DEFAULT_CLIENT_NAME,
+    CloudError,
+    CloudProfile,
+    CloudUnavailableError,
+    Http,
+    PairingClient,
+    PollStatus,
+    ProfileStore,
+    RefusedError,
+)
+from .models import (
+    ConnectionData,
+    ErrorInfo,
+    PairingDisplay,
+    connection_from_profile,
+    error_from,
+    idle_push,
+    push_from_store,
+    resolve_urls,
+    to_payload,
+    utc_now,
+)
+
+#: The two poll outcomes that end a pairing without a key.
+_TERMINAL_POLL_KINDS = {
+    PollStatus.EXPIRED: ErrorKind.PAIRING_EXPIRED,
+    PollStatus.DENIED: ErrorKind.PAIRING_DENIED,
+}
+
+_POLL_STATUS_VALUES = {
+    PollStatus.PENDING: PollStatusValue.PENDING,
+    PollStatus.SLOW_DOWN: PollStatusValue.SLOW_DOWN,
+    PollStatus.ISSUED: PollStatusValue.ISSUED,
+    PollStatus.EXPIRED: PollStatusValue.EXPIRED,
+    PollStatus.DENIED: PollStatusValue.DENIED,
+}
+
+
+class CloudPanel(foo.Panel):
+    """``@voxel51/cloud/cloud_panel`` — "FiftyOne Cloud", grid surface.
+
+    Renders a single React component and exposes its methods on the view;
+    the browser reads their URIs off ``props.schema.view`` and calls them
+    through ``useTriggerPanelEvent``, whose callback receives the return
+    value as ``result.result``.
+    """
+
+    def __init__(self, _builtin=False):
+        super().__init__(_builtin=_builtin)
+        # The registry holds one instance, so this cache is shared across
+        # sessions. That is fine: it is keyed on the selection it describes,
+        # and a miss costs exactly what not caching would.
+        self.__counts_key: Any = None
+        self.__counts_value: "tuple[int, int]" = (0, 0)
+
+    @property
+    def config(self) -> foo.PanelConfig:
+        return foo.PanelConfig(
+            name=PANEL_NAME,
+            label=PANEL_LABEL,
+            icon="cloud_upload",
+            surfaces="grid",
+        )
+
+    def store(self, ctx) -> Any:
+        """``ctx.store(STORE_NAME)`` — dataset-scoped by construction, which
+        is why there is no cross-dataset view of running uploads."""
+        return ctx.store(STORE_NAME)
+
+    # --- lifecycle --------------------------------------------------------
+
+    def on_load(self, ctx) -> None:
+        """Seeds both halves of panel data.
+
+        Never reads panel data back (``PanelRefData.get`` raises
+        ``WriteOnlyError``).
+        """
+        # Opening the panel is the one moment worth paying for fresh counts:
+        # the cache is otherwise only invalidated by a view change, so
+        # samples added since it was last computed would show stale.
+        self.__counts_key = None
+
+        profile = ProfileStore().load()
+        api_url, auth_url = resolve_urls(profile)
+        self.__write_connection(
+            ctx, connection_from_profile(profile, api_url, auth_url)
+        )
+
+        stored = self.store(ctx).get(PUSH_KEY)
+        self.__write_push(ctx, push_from_store(stored, _local_dataset(ctx)))
+
+    # --- pairing ----------------------------------------------------------
+
+    def start_pairing(self, ctx) -> Dict[str, Any]:
+        """params: ``api_url``, ``auth_url`` (both optional; fall back to
+        ``resolve_urls``). Returns the full ``DevicePairing`` as a dict,
+        ``device_code`` included — the return value goes to the caller, not
+        into panel data.
+        """
+        profile_store = ProfileStore()
+        api_url, auth_url = self.__requested_urls(ctx, profile_store.load())
+
+        # Saved before the request so a pairing the user cancels — or one
+        # that never starts — still leaves the form prefilled.
+        keyless = CloudProfile(api_url=api_url, auth_url=auth_url)
+        profile_store.save(keyless)
+
+        try:
+            pairing = PairingClient(auth_url, Http()).start(
+                DEFAULT_CLIENT_NAME, foc.VERSION
+            )
+        except CloudError as error:
+            self.__write_connection(
+                ctx,
+                connection_from_profile(
+                    keyless, api_url, auth_url, error=error_from(error)
+                ),
+            )
+            return {}
+
+        self.__write_connection(
+            ctx,
+            ConnectionData(
+                status=ConnectionStatus.PAIRING,
+                api_url=api_url,
+                auth_url=auth_url,
+                pairing=PairingDisplay(
+                    user_code=pairing.user_code,
+                    verification_uri=pairing.verification_uri,
+                    verification_uri_complete=(
+                        pairing.verification_uri_complete
+                    ),
+                    expires_at=utc_now()
+                    + datetime.timedelta(seconds=pairing.expires_in),
+                    interval=pairing.interval,
+                ),
+            ),
+        )
+        return to_payload(pairing)
+
+    def poll_pairing(self, ctx) -> Dict[str, Any]:
+        """params: ``device_code``, ``api_url``, ``auth_url``. Returns
+        ``{"status": PollStatusValue, "message"?: str}``.
+
+        ``RefusedError`` and ``CloudUnavailableError`` are caught and
+        reported as statuses rather than raised — a poll that throws would
+        strand the browser's interval.
+        """
+        device_code = ctx.params.get(ParamKey.DEVICE_CODE.value)
+        profile_store = ProfileStore()
+        profile = profile_store.load()
+        api_url, auth_url = self.__requested_urls(ctx, profile)
+
+        try:
+            outcome = PairingClient(auth_url, Http()).poll(device_code)
+        except (RefusedError, CloudUnavailableError) as error:
+            info = error_from(error)
+            self.__write_connection(
+                ctx,
+                connection_from_profile(
+                    profile, api_url, auth_url, error=info
+                ),
+            )
+            return {
+                "status": (
+                    PollStatusValue.REFUSED.value
+                    if isinstance(error, RefusedError)
+                    else PollStatusValue.UNAVAILABLE.value
+                ),
+                "message": info.message,
+            }
+
+        if outcome.status is PollStatus.ISSUED:
+            paired = _base_profile(profile, api_url, auth_url).with_key(
+                outcome.issued.api_key,
+                outcome.issued.scope,
+                _expiry(outcome.issued.expires_in),
+            )
+            profile_store.save(paired)
+            self.__write_connection(
+                ctx, connection_from_profile(paired, api_url, auth_url)
+            )
+            return {"status": PollStatusValue.ISSUED.value}
+
+        kind = _TERMINAL_POLL_KINDS.get(outcome.status)
+        if kind is not None:
+            self.__write_connection(
+                ctx,
+                connection_from_profile(
+                    profile,
+                    api_url,
+                    auth_url,
+                    error=ErrorInfo(kind=kind, message=""),
+                ),
+            )
+
+        return {"status": _POLL_STATUS_VALUES[outcome.status].value}
+
+    def cancel_pairing(self, ctx) -> Dict[str, Any]:
+        """No params. Connection back to DISCONNECTED with the URLs kept —
+        the keyless profile ``start_pairing`` saved is already correct, so
+        this only rewrites panel data."""
+        profile = ProfileStore().load()
+        api_url, auth_url = resolve_urls(profile)
+        self.__write_connection(
+            ctx, connection_from_profile(profile, api_url, auth_url)
+        )
+        return {}
+
+    # --- connection -------------------------------------------------------
+
+    def disconnect(self, ctx) -> Dict[str, Any]:
+        """No params. Saves the profile ``without_key()`` — never
+        ``clear()``, which would take the URLs with it.
+
+        There is no server-side key revocation: connected means "a key is
+        present and unexpired", so dropping the key is the whole operation.
+        """
+        profile_store = ProfileStore()
+        profile = profile_store.load()
+        if profile is not None:
+            profile = profile.without_key()
+            profile_store.save(profile)
+
+        api_url, auth_url = resolve_urls(profile)
+        self.__write_connection(
+            ctx, connection_from_profile(profile, api_url, auth_url)
+        )
+        self.__write_push(ctx, idle_push(_local_dataset(ctx)))
+        return {}
+
+    # --- push -------------------------------------------------------------
+
+    def reset_push(self, ctx) -> Dict[str, Any]:
+        """No params. Backs "Upload another" and "Try again", so a stale
+        terminal snapshot cannot reappear on the next ``on_load``."""
+        self.store(ctx).delete(PUSH_KEY)
+        self.__write_push(ctx, idle_push(_local_dataset(ctx)))
+        return {}
+
+    # --- render -----------------------------------------------------------
+
+    def render(self, ctx) -> types.Property:
+        """A single composite view.
+
+        Carries the dataset context the React side cannot derive — the local
+        name, both sample counts, and whether a view is active — so the
+        Upload form can offer the view/dataset choice without a round trip.
+        ``render`` runs after every panel method, so nothing here may cost
+        more than a count.
+        """
+        has_view = bool(ctx.has_custom_view)
+        dataset_count, view_count = self.__counts(ctx, has_view)
+        return types.Property(
+            types.Object(),
+            view=types.View(
+                component=PANEL_COMPONENT,
+                composite_view=True,
+                start_pairing=self.start_pairing,
+                poll_pairing=self.poll_pairing,
+                cancel_pairing=self.cancel_pairing,
+                disconnect=self.disconnect,
+                reset_push=self.reset_push,
+                local_dataset=_local_dataset(ctx),
+                dataset_count=dataset_count,
+                view_count=view_count,
+                has_view=has_view,
+            ),
+        )
+
+    # --- internals --------------------------------------------------------
+
+    def __counts(self, ctx, has_view: bool) -> "tuple[int, int]":
+        """``(dataset_count, view_count)``, memoized on the selection.
+
+        ``render`` runs after *every* panel method, including each pairing
+        poll at the RFC interval, and a count over a filtered or generated
+        view is a full aggregation. The counts only change when the dataset
+        or the view stages do, so key the cache on exactly that.
+        """
+        key = (
+            _local_dataset(ctx),
+            _view_signature(ctx) if has_view else None,
+        )
+        if self.__counts_key != key:
+            dataset_count = _count(ctx.dataset)
+            self.__counts_key = key
+            self.__counts_value = (
+                dataset_count,
+                _count(ctx.view) if has_view else dataset_count,
+            )
+        return self.__counts_value
+
+    def __requested_urls(self, ctx, profile) -> "tuple[str, str]":
+        """The URLs the browser sent, falling back to the resolution chain
+        for whichever half it left blank."""
+        api_url, auth_url = resolve_urls(profile)
+        requested_api = ctx.params.get(ParamKey.API_URL.value)
+        requested_auth = ctx.params.get(ParamKey.AUTH_URL.value)
+        return (
+            (requested_api or api_url).rstrip("/"),
+            (requested_auth or auth_url).rstrip("/"),
+        )
+
+    def __write_connection(self, ctx, connection: ConnectionData) -> None:
+        ctx.panel.set_data(
+            PanelDataKey.CONNECTION.value, to_payload(connection)
+        )
+
+    def __write_push(self, ctx, push) -> None:
+        ctx.panel.set_data(PanelDataKey.PUSH.value, to_payload(push))
+
+
+def _base_profile(
+    profile: Optional[CloudProfile], api_url: str, auth_url: str
+) -> CloudProfile:
+    """The profile a newly issued key attaches to. A stored profile whose
+    URLs the user has since changed is not it."""
+    if (
+        profile is not None
+        and profile.api_url == api_url
+        and profile.auth_url == auth_url
+    ):
+        return profile
+    return CloudProfile(api_url=api_url, auth_url=auth_url)
+
+
+def _expiry(expires_in: Optional[int]) -> Optional[datetime.datetime]:
+    if expires_in is None:
+        return None
+    return utc_now() + datetime.timedelta(seconds=expires_in)
+
+
+def _view_signature(ctx) -> str:
+    """A cheap identity for the active view.
+
+    The four request params ``has_custom_view`` reads *are* the view — the
+    stages, filters, extended selection and saved-view name the App sent —
+    so hashing them needs no database round trip.
+    """
+    params = getattr(ctx, "request_params", None) or {}
+    return repr(
+        [
+            params.get("view"),
+            params.get("filters"),
+            params.get("extended"),
+            params.get("view_name"),
+        ]
+    )
+
+
+def _local_dataset(ctx) -> str:
+    return getattr(ctx.dataset, "name", "") or ""
+
+
+def _count(collection) -> int:
+    if collection is None:
+        return 0
+    return len(collection)

--- a/local-plugins/cloud/plan_cache.py
+++ b/local-plugins/cloud/plan_cache.py
@@ -1,0 +1,113 @@
+"""
+A parking spot for a built plan between the preview and the confirm.
+
+``build_push_plan`` walks every sample — ``isfile``, ``getsize``,
+``to_dict`` — which is seconds to minutes on a real dataset, and the user
+sees the numbers it produced before deciding. Handing the confirm the same
+plan object turns two scans into one.
+
+In-process on purpose. The execution store is not an option: a ``PushPlan``
+carries every sample document and blows the 16 MB value cap. Losing the
+cache to a server restart costs one rebuild, which ``push_to_cloud`` already
+handles by emitting ``planning`` and planning again.
+"""
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from .constants import PLAN_CACHE_TTL_S
+
+
+@dataclass(frozen=True)
+class PlanEntry:
+    """A parked plan plus what it was built for and when."""
+
+    plan: Any
+    local_dataset: str
+    target: str
+    created_at: float
+
+
+class PlanCache:
+    """Module-level, thread-safe, TTL'd. Tokens are opaque and single-use.
+
+    The token travels to the browser in ``push.plan_token`` and comes back
+    on ``mode="push"``; it names nothing about the dataset, so echoing it
+    through panel data leaks nothing.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: float = PLAN_CACHE_TTL_S,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.__entries: Dict[str, "PlanEntry"] = {}
+        self.__lock = threading.Lock()
+        self.__ttl = ttl_seconds
+        self.__clock = clock
+
+    def put(self, plan: Any, local_dataset: str, target: str) -> str:
+        """Parks a ``PushPlan`` and returns its token.
+
+        ``local_dataset`` and ``target`` are stored alongside so
+        :meth:`take` can refuse a token whose plan was built for a
+        different selection — an expired-then-rebuilt plan is correct, a
+        mismatched one is not. Purges expired entries on the way in so the
+        cache cannot grow without bound.
+        """
+        token = uuid.uuid4().hex
+        now = self.__clock()
+        with self.__lock:
+            self.__purge(now)
+            self.__entries[token] = PlanEntry(
+                plan=plan,
+                local_dataset=local_dataset,
+                target=target,
+                created_at=now,
+            )
+        return token
+
+    def take(
+        self, token: Optional[str], local_dataset: str, target: str
+    ) -> Optional[Any]:
+        """Removes and returns the plan for ``token``.
+
+        Returns ``None`` on an absent, expired, or mismatched token — every
+        one of which the caller handles identically, by rebuilding.
+        """
+        if not token:
+            return None
+
+        now = self.__clock()
+        with self.__lock:
+            self.__purge(now)
+            entry = self.__entries.pop(token, None)
+
+        if entry is None:
+            return None
+        if entry.local_dataset != local_dataset or entry.target != target:
+            return None
+        return entry.plan
+
+    def clear(self) -> None:
+        """Drops everything. Tests only."""
+        with self.__lock:
+            self.__entries.clear()
+
+    def __purge(self, now: float) -> None:
+        """Caller holds the lock."""
+        expired = [
+            token
+            for token, entry in self.__entries.items()
+            if now - entry.created_at > self.__ttl
+        ]
+        for token in expired:
+            del self.__entries[token]
+
+
+#: The one cache. Module-level so the preview execution and the confirm
+#: execution — different requests, same process — see the same entries.
+PLAN_CACHE = PlanCache()

--- a/local-plugins/cloud/progress.py
+++ b/local-plugins/cloud/progress.py
@@ -1,0 +1,300 @@
+"""
+Two progress channels over one event stream, each owned by the thread that
+can actually guarantee it.
+
+``PanelDataSink`` is the live channel and belongs to the generator's drain
+loop on the request thread: it yields ``patch_panel_data`` invocation
+requests, so it can only be driven from inside the generator, and it dies
+with the request stream. ``StoreSink`` is the durable channel and belongs to
+the upload worker: it is called from ``on_progress`` on worker threads,
+takes its own lock, and writes the terminal snapshot itself before the
+worker sets its result slot. Nothing durable depends on ``GeneratorExit``,
+whose timing under Starlette's threadpool iteration is GC-dependent.
+
+Every ``emit`` does its work eagerly and returns an iterator over whatever
+the caller still has to yield. A generator-function ``emit`` would defer a
+store write until somebody drained it, and the worker never drains.
+"""
+
+import abc
+import logging
+import queue
+import threading
+import time
+from typing import Any, Callable, Iterator, List, Optional, Tuple
+
+from .constants import (
+    PANEL_THROTTLE_S,
+    PUSH_KEY,
+    QUEUE_POLL_S,
+    STORE_THROTTLE_S,
+    TERMINAL_TTL_S,
+    PanelDataKey,
+)
+from .models import (
+    PushData,
+    done_push,
+    error_from,
+    failed_push,
+    push_from_event,
+    to_payload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Throttle:
+    """Rate-limits a stream of snapshots, with mandatory escapes.
+
+    A snapshot passes when the interval has elapsed, when its key (the
+    fields the caller says are structural) differs from the last one that
+    passed, or when it is terminal. Not thread-safe on its own — callers
+    that share one across threads hold their own lock.
+    """
+
+    def __init__(
+        self,
+        interval: float,
+        key: Callable[[PushData], Tuple[Any, ...]],
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._interval = interval
+        self._key = key
+        self._clock = clock
+        self._last_at: Optional[float] = None
+        self._last_key: Optional[Tuple[Any, ...]] = None
+
+    def allow(self, snapshot: PushData) -> bool:
+        """True when this snapshot should be emitted; records it as emitted
+        when so."""
+        key = self._key(snapshot)
+        now = self._clock()
+
+        elapsed = (
+            self._last_at is None or now - self._last_at >= self._interval
+        )
+        if elapsed or key != self._last_key or snapshot.status.is_terminal:
+            self._last_at = now
+            self._last_key = key
+            return True
+
+        return False
+
+
+class ProgressSink(abc.ABC):
+    """Somewhere a push snapshot goes.
+
+    ``emit`` returns an iterator of invocation requests so a sink that has
+    to reach the App can hand work back to the generator; sinks that write
+    server-side yield nothing. Callers always drain the iterator — a bare
+    call does nothing for a generator-backed sink.
+    """
+
+    @abc.abstractmethod
+    def emit(self, snapshot: PushData) -> Iterator[Any]:
+        """Consumes one complete snapshot."""
+
+
+class PanelDataSink(ProgressSink):
+    """Request-thread only. Yields one ``ctx.ops.patch_panel_data`` request
+    per admitted snapshot, addressed to the caller's ``panel_id``.
+
+    Throttled at ``PANEL_THROTTLE_S`` keyed on ``(status, stage)``, so a
+    stage change or a terminal snapshot always gets through.
+    """
+
+    def __init__(self, ctx: Any, panel_id: str):
+        self._ctx = ctx
+        self._panel_id = panel_id
+        self._throttle = Throttle(
+            PANEL_THROTTLE_S,
+            key=lambda snapshot: (snapshot.status, snapshot.stage),
+        )
+
+    def emit(self, snapshot: PushData) -> Iterator[Any]:
+        """Yields ``ctx.ops.patch_panel_data({PanelDataKey.PUSH: payload},
+        panel_id=...)`` when the throttle admits the snapshot."""
+        if not self._throttle.allow(snapshot):
+            return iter(())
+
+        request = self._ctx.ops.patch_panel_data(
+            {PanelDataKey.PUSH.value: to_payload(snapshot)},
+            panel_id=self._panel_id,
+        )
+        return iter((request,))
+
+
+class StoreSink(ProgressSink):
+    """Worker-owned and thread-safe. Writes the snapshot to the
+    ``cloud_push`` execution store under ``PUSH_KEY``; yields nothing.
+
+    Throttled at ``STORE_THROTTLE_S`` keyed on ``status`` alone (the store
+    is the recovery channel, not the animation), behind its own lock because
+    ``on_progress`` fires on several upload threads. Terminal snapshots are
+    written with ``ttl=TERMINAL_TTL_S``; everything else without a TTL.
+
+    Store faults are swallowed and logged: losing the durable channel must
+    never abort a push that is otherwise fine.
+    """
+
+    def __init__(self, store: Any):
+        self._store = store
+        self._lock = threading.Lock()
+        self._throttle = Throttle(
+            STORE_THROTTLE_S, key=lambda snapshot: (snapshot.status,)
+        )
+
+    def emit(self, snapshot: PushData) -> Iterator[Any]:
+        """Writes through the lock when the throttle admits; yields nothing."""
+        with self._lock:
+            if not self._throttle.allow(snapshot):
+                return iter(())
+
+            ttl = TERMINAL_TTL_S if snapshot.status.is_terminal else None
+            try:
+                self._store.set(PUSH_KEY, to_payload(snapshot), ttl=ttl)
+            except Exception:  # noqa: BLE001 - recovery is best-effort
+                logger.warning(
+                    "cloud push: could not record progress in the execution "
+                    "store; the upload continues",
+                    exc_info=True,
+                )
+
+        return iter(())
+
+
+class CompositeSink(ProgressSink):
+    """Fans one snapshot out to several sinks in order, concatenating
+    whatever they yield. Used for the snapshots the request thread owns
+    (planning, preview, the initial running tick, the terminal one)."""
+
+    def __init__(self, sinks: List[ProgressSink]):
+        self._sinks = list(sinks)
+
+    def emit(self, snapshot: PushData) -> Iterator[Any]:
+        requests: List[Any] = []
+        for sink in self._sinks:
+            requests.extend(sink.emit(snapshot))
+        return iter(requests)
+
+
+class PushWorker:
+    """Runs ``run_push`` off the request thread and bridges its progress.
+
+    ``on_progress`` — already invoked on the upload workers — writes to the
+    ``StoreSink`` directly and then puts the raw ``PushEvent`` on a queue
+    the generator drains at ``QUEUE_POLL_S``. The worker writes its own
+    terminal snapshot to the store before publishing its result, so a
+    request stream that vanished still leaves a correct final state.
+
+    The thread is a daemon and is never cancelled: the state file flushes
+    every 20 uploads, so a re-run resumes whether it finished or died with
+    the server.
+    """
+
+    def __init__(
+        self,
+        run: Callable[[Callable[[Any], None]], Any],
+        store_sink: StoreSink,
+        local_dataset: str,
+        dataset_name: str,
+    ):
+        self._run = run
+        self._store_sink = store_sink
+        self._local_dataset = local_dataset
+        self._dataset_name = dataset_name
+        self._events: "queue.Queue[Any]" = queue.Queue()
+        self._thread: Optional[threading.Thread] = None
+        self._outcome: Optional[Any] = None
+        self._error: Optional[BaseException] = None
+        self._snapshot: Optional[PushData] = None
+
+    def start(self) -> None:
+        """Spawns the daemon thread."""
+        self._thread = threading.Thread(
+            target=self.__work, name="cloud-push", daemon=True
+        )
+        self._thread.start()
+
+    def __work(self) -> None:
+        try:
+            outcome = self._run(self.__on_progress)
+        except BaseException as error:  # noqa: BLE001 - reported, not raised
+            snapshot = failed_push(
+                self._local_dataset, self._dataset_name, error_from(error)
+            )
+            self.__publish(snapshot, outcome=None, error=error)
+            return
+
+        snapshot = done_push(self._local_dataset, self._dataset_name, outcome)
+        self.__publish(snapshot, outcome=outcome, error=None)
+
+    def __publish(
+        self,
+        snapshot: PushData,
+        outcome: Optional[Any],
+        error: Optional[BaseException],
+    ) -> None:
+        """Durable state first, then the result slot.
+
+        The order is the contract: whoever observes a finished worker must
+        be looking at a store that already agrees with it.
+        """
+        list(self._store_sink.emit(snapshot))
+        self._snapshot = snapshot
+        self._outcome = outcome
+        self._error = error
+
+    def __on_progress(self, event: Any) -> None:
+        """Runs on the pusher's upload threads."""
+        list(
+            self._store_sink.emit(
+                push_from_event(event, self._local_dataset, self._dataset_name)
+            )
+        )
+        self._events.put(event)
+
+    def drain(self, panel_sink: ProgressSink) -> Iterator[Any]:
+        """Generator-side loop, on the request thread.
+
+        Polls the queue at ``QUEUE_POLL_S``; for each event, builds the
+        running snapshot and yields whatever ``panel_sink`` yields. The sink
+        is passed in rather than held, because it is request-scoped and the
+        worker is not.
+        Exits when the worker thread is finished and the queue is drained.
+        Does not itself write the terminal snapshot — the caller reads
+        :meth:`result` and emits it.
+        """
+        while True:
+            try:
+                event = self._events.get(timeout=QUEUE_POLL_S)
+            except queue.Empty:
+                if self._thread is None or not self._thread.is_alive():
+                    break
+                continue
+            yield from panel_sink.emit(
+                push_from_event(event, self._local_dataset, self._dataset_name)
+            )
+
+        while True:
+            try:
+                event = self._events.get_nowait()
+            except queue.Empty:
+                return
+            yield from panel_sink.emit(
+                push_from_event(event, self._local_dataset, self._dataset_name)
+            )
+
+    def result(self) -> Tuple[Optional[Any], Optional[BaseException]]:
+        """The worker's ``(PushOutcome, exception)`` slot, exactly one of
+        which is set once the thread has finished."""
+        return self._outcome, self._error
+
+    def snapshot(self) -> Optional[PushData]:
+        """The terminal snapshot the worker wrote to the store.
+
+        The operator emits this exact object to panel data, so the live and
+        durable channels cannot disagree about the final frame — rebuilding
+        it on the request thread would re-stamp ``updated_at``.
+        """
+        return self._snapshot

--- a/local-plugins/cloud/tests/test_operators.py
+++ b/local-plugins/cloud/tests/test_operators.py
@@ -1,0 +1,474 @@
+"""
+``push_to_cloud``: the sequencing contract.
+
+Every assertion here is about *what was emitted, in what order* — the panel
+is a state machine and the operator is its only producer, so a missing or
+out-of-order snapshot is a stuck UI.
+"""
+
+import datetime
+
+import pytest
+from conftest import FakeCtx, FakeSample
+
+import cloud.operators as operators_module
+from cloud.constants import (
+    ALREADY_RUNNING_MESSAGE,
+    PANEL_NAME,
+    PUSH_KEY,
+    REJECTED_PREVIEW_LIMIT,
+    RUNNING_GUARD_S,
+    STORE_NAME,
+    ConnectionStatus,
+    ErrorKind,
+    PanelDataKey,
+    PushStatus,
+)
+from cloud.engine import (
+    CloudProfile,
+    CloudUnavailableError,
+    KeyRefusedError,
+    ProfileStore,
+    PushEvent,
+    PushOutcome,
+    PushStage,
+    PushState,
+    RefusedError,
+    RejectedSample,
+    SessionExpiredError,
+)
+from cloud.engine.session import BatchLimits
+from cloud.models import iso, utc_now
+from cloud.operators import CloudPushSubscription, OpenCloudPanel, PushToCloud
+from cloud.plan_cache import PLAN_CACHE
+
+API_URL = "https://api.example.com"
+AUTH_URL = "https://auth.example.com/cas/api"
+
+
+@pytest.fixture(name="paired", autouse=True)
+def fixture_paired(profile_dir):
+    ProfileStore().save(
+        CloudProfile(api_url=API_URL, auth_url=AUTH_URL, api_key="kid|raw")
+    )
+    PLAN_CACHE.clear()
+    yield
+    PLAN_CACHE.clear()
+
+
+@pytest.fixture(name="media")
+def fixture_media(tmp_path):
+    """Two real files plus one path that isn't there, so the plan has a
+    missing entry without any mocking of the filesystem."""
+    files = []
+    for index in range(2):
+        path = tmp_path / f"image-{index}.jpg"
+        path.write_bytes(b"x" * (10 + index))
+        files.append(str(path))
+    return files + [str(tmp_path / "gone.jpg")]
+
+
+def ctx_for(media, **params):
+    ctx = FakeCtx(
+        params={
+            "target": "dataset",
+            "dataset_name": "cloud-ds",
+            "panel_id": "panel-1",
+            **params,
+        }
+    )
+    ctx.dataset.samples = [FakeSample(filepath=path) for path in media]
+    return ctx
+
+
+def pushes(requests):
+    """The push snapshots a run yielded, in order."""
+    return [
+        request.params["data"][PanelDataKey.PUSH.value]
+        for request in requests
+        if PanelDataKey.PUSH.value in request.params["data"]
+    ]
+
+
+def statuses(requests):
+    return [snapshot["status"] for snapshot in pushes(requests)]
+
+
+def outcome_with(**overrides):
+    defaults = dict(
+        dataset="cloud-ds",
+        session_id="sess-1",
+        uploaded=2,
+        skipped_uploads=0,
+        missing_files=1,
+        accepted=2,
+        rejected=[],
+        samples=2,
+        shortfall=0,
+    )
+    defaults.update(overrides)
+    return PushOutcome(**defaults)
+
+
+def fake_run_push(outcome=None, events=(), error=None):
+    calls = []
+
+    def run_push(profile, dataset_name, samples, http, **kwargs):
+        calls.append({"dataset_name": dataset_name, **kwargs})
+        for event in events:
+            kwargs["on_progress"](event)
+        if error is not None:
+            raise error
+        return outcome or outcome_with()
+
+    run_push.calls = calls
+    return run_push
+
+
+def stored_push(status, age_seconds=0):
+    return {
+        "status": status.value,
+        "updated_at": iso(utc_now() - datetime.timedelta(seconds=age_seconds)),
+        "local_dataset": "local-dataset",
+    }
+
+
+# --- preview mode ---------------------------------------------------------
+
+
+def test_preview_emits_planning_before_it_scans(media, monkeypatch):
+    scanned = []
+    real_plan = operators_module.build_push_plan
+
+    def spy(samples):
+        scanned.append(True)
+        return real_plan(samples)
+
+    monkeypatch.setattr(operators_module, "build_push_plan", spy)
+    ctx = ctx_for(media, mode="preview")
+
+    generator = PushToCloud().execute(ctx)
+    first = next(generator)
+
+    assert (
+        first.params["data"][PanelDataKey.PUSH.value]["status"]
+        == PushStatus.PLANNING.value
+    )
+    # The scan is seconds to minutes; the spinner has to be on screen first.
+    assert scanned == []
+
+    list(generator)
+    assert scanned == [True]
+
+
+def test_preview_emits_counts_and_a_plan_token(media):
+    ctx = ctx_for(media, mode="preview")
+
+    snapshots = pushes(list(PushToCloud().execute(ctx)))
+
+    assert [item["status"] for item in snapshots] == [
+        PushStatus.PLANNING.value,
+        PushStatus.PREVIEW.value,
+    ]
+    preview = snapshots[-1]["preview"]
+    assert preview == {
+        "samples": 2,
+        "files": 2,
+        "total_bytes": 21,
+        "missing": 1,
+    }
+    token = snapshots[-1]["plan_token"]
+    assert PLAN_CACHE.take(token, "local-dataset", "dataset") is not None
+
+
+def test_preview_reports_resumable_when_a_state_file_exists(
+    media, monkeypatch
+):
+    seen = {}
+
+    class FakeStateStore:
+        def __init__(self, api_url, dataset_name):
+            seen["dataset_name"] = dataset_name
+
+        def load(self):
+            return PushState(
+                session_id="s",
+                prefix="p/",
+                store_root="gs://b",
+                limits=BatchLimits(1, 1),
+                uploaded_keys=["media/image-0.jpg"],
+            )
+
+    monkeypatch.setattr(operators_module, "PushStateStore", FakeStateStore)
+    ctx = ctx_for(media, mode="preview")
+
+    snapshots = pushes(list(PushToCloud().execute(ctx)))
+
+    # Resume state is keyed on the *cloud* name the user typed, not the
+    # local one.
+    assert seen["dataset_name"] == "cloud-ds"
+    assert snapshots[-1]["resumable"] == {"uploaded": 1, "total": 2}
+
+
+def test_preview_omits_resumable_when_no_state_file_exists(media):
+    ctx = ctx_for(media, mode="preview")
+
+    snapshots = pushes(list(PushToCloud().execute(ctx)))
+
+    # Absent, not zeroed — the App branches on presence.
+    assert "resumable" not in snapshots[-1]
+
+
+# --- push mode ------------------------------------------------------------
+
+
+def test_push_reuses_the_cached_plan(media, monkeypatch):
+    ctx = ctx_for(media, mode="preview")
+    token = pushes(list(PushToCloud().execute(ctx)))[-1]["plan_token"]
+
+    run_push = fake_run_push()
+    monkeypatch.setattr(operators_module, "run_push", run_push)
+    monkeypatch.setattr(
+        operators_module,
+        "build_push_plan",
+        lambda samples: pytest.fail("the cached plan should have been used"),
+    )
+
+    ctx = ctx_for(media, mode="push", plan_token=token)
+    result = statuses(list(PushToCloud().execute(ctx)))
+
+    assert PushStatus.PLANNING.value not in result
+    assert run_push.calls[0]["plan"] is not None
+
+
+def test_push_rebuilds_and_re_emits_planning_on_a_cache_miss(
+    media, monkeypatch
+):
+    monkeypatch.setattr(operators_module, "run_push", fake_run_push())
+    ctx = ctx_for(media, mode="push", plan_token="expired-token")
+
+    result = statuses(list(PushToCloud().execute(ctx)))
+
+    assert result[0] == PushStatus.PLANNING.value
+    assert result[-1] == PushStatus.DONE.value
+
+
+def test_push_emits_a_zero_running_snapshot_before_any_file_completes(
+    media, monkeypatch
+):
+    monkeypatch.setattr(operators_module, "run_push", fake_run_push())
+    ctx = ctx_for(media, mode="push")
+
+    snapshots = pushes(list(PushToCloud().execute(ctx)))
+    running = [
+        item
+        for item in snapshots
+        if item["status"] == PushStatus.RUNNING.value
+    ]
+
+    assert running[0]["done"] == 0
+    assert running[0]["total"] == 2
+    assert running[0]["stage"] == PushStage.UPLOADING.value
+
+
+def test_push_streams_a_stage_change_past_the_throttle(media, monkeypatch):
+    """Same-stage ticks inside 250 ms coalesce by design; a stage change
+    never may, or the label lags the bar."""
+    monkeypatch.setattr(
+        operators_module,
+        "run_push",
+        fake_run_push(
+            events=[
+                PushEvent(PushStage.UPLOADING, 1, 2, "a"),
+                PushEvent(PushStage.INGESTING, 1, 1, "b"),
+                PushEvent(PushStage.CLOSING, 0, 1, ""),
+            ]
+        ),
+    )
+    ctx = ctx_for(media, mode="push")
+
+    stages = [
+        item.get("stage")
+        for item in pushes(list(PushToCloud().execute(ctx)))
+        if item["status"] == PushStatus.RUNNING.value
+    ]
+
+    assert stages[0] == PushStage.UPLOADING.value
+    assert stages[-2:] == [
+        PushStage.INGESTING.value,
+        PushStage.CLOSING.value,
+    ]
+
+
+def test_push_refuses_while_a_fresh_running_snapshot_exists(
+    media, monkeypatch
+):
+    monkeypatch.setattr(
+        operators_module,
+        "run_push",
+        lambda *a, **k: pytest.fail("no second worker may start"),
+    )
+    ctx = ctx_for(media, mode="push")
+    ctx.store_.values[PUSH_KEY] = stored_push(PushStatus.RUNNING, 1)
+
+    snapshots = pushes(list(PushToCloud().execute(ctx)))
+
+    assert snapshots[-1]["status"] == PushStatus.FAILED.value
+    assert snapshots[-1]["error"]["kind"] == ErrorKind.REFUSED.value
+    assert snapshots[-1]["error"]["message"] == ALREADY_RUNNING_MESSAGE
+
+
+def test_push_proceeds_when_the_running_snapshot_is_stale(media, monkeypatch):
+    monkeypatch.setattr(operators_module, "run_push", fake_run_push())
+    ctx = ctx_for(media, mode="push")
+    ctx.store_.values[PUSH_KEY] = stored_push(
+        PushStatus.RUNNING, RUNNING_GUARD_S + 5
+    )
+
+    assert (
+        statuses(list(PushToCloud().execute(ctx)))[-1] == PushStatus.DONE.value
+    )
+
+
+def test_push_terminal_snapshot_reaches_both_channels(media, monkeypatch):
+    monkeypatch.setattr(operators_module, "run_push", fake_run_push())
+    ctx = ctx_for(media, mode="push")
+
+    panel_terminal = pushes(list(PushToCloud().execute(ctx)))[-1]
+
+    assert panel_terminal["status"] == PushStatus.DONE.value
+    assert ctx.store_.values[PUSH_KEY] == panel_terminal
+
+
+def test_push_caps_the_rejected_list_but_not_the_count(media, monkeypatch):
+    rejected = [RejectedSample(index=i, reason="bad") for i in range(50)]
+    monkeypatch.setattr(
+        operators_module,
+        "run_push",
+        fake_run_push(outcome=outcome_with(rejected=rejected)),
+    )
+    ctx = ctx_for(media, mode="push")
+
+    outcome = pushes(list(PushToCloud().execute(ctx)))[-1]["outcome"]
+
+    assert outcome["rejected_count"] == 50
+    assert len(outcome["rejected"]) == REJECTED_PREVIEW_LIMIT
+
+
+@pytest.mark.parametrize(
+    "error,kind",
+    [
+        (CloudUnavailableError("down"), ErrorKind.UNAVAILABLE),
+        (RefusedError("nope"), ErrorKind.REFUSED),
+        (SessionExpiredError("stale"), ErrorKind.SESSION_EXPIRED),
+        (KeyRefusedError("bad key"), ErrorKind.KEY_REFUSED),
+        (ValueError("who knows"), ErrorKind.UNKNOWN),
+    ],
+)
+def test_push_failure_maps_the_error_kind(media, monkeypatch, error, kind):
+    monkeypatch.setattr(
+        operators_module, "run_push", fake_run_push(error=error)
+    )
+    ctx = ctx_for(media, mode="push")
+
+    terminal = pushes(list(PushToCloud().execute(ctx)))[-1]
+
+    assert terminal["status"] == PushStatus.FAILED.value
+    assert terminal["error"]["kind"] == kind.value
+
+
+def test_push_honors_the_fresh_flag(media, monkeypatch):
+    run_push = fake_run_push()
+    monkeypatch.setattr(operators_module, "run_push", run_push)
+    ctx = ctx_for(media, mode="push", fresh=True)
+
+    list(PushToCloud().execute(ctx))
+
+    assert run_push.calls[0]["fresh"] is True
+
+
+# --- both modes -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["preview", "push"])
+def test_unpaired_emits_not_paired_and_disconnects_the_connection(media, mode):
+    ProfileStore().save(CloudProfile(api_url=API_URL, auth_url=AUTH_URL))
+    ctx = ctx_for(media, mode=mode)
+
+    requests = list(PushToCloud().execute(ctx))
+
+    terminal = pushes(requests)[-1]
+    assert terminal["status"] == PushStatus.FAILED.value
+    assert terminal["error"]["kind"] == ErrorKind.NOT_PAIRED.value
+
+    connection = [
+        request.params["data"][PanelDataKey.CONNECTION.value]
+        for request in requests
+        if PanelDataKey.CONNECTION.value in request.params["data"]
+    ][-1]
+    # The panel must drop to Connect rather than show a dead upload form.
+    assert connection["status"] == ConnectionStatus.DISCONNECTED.value
+    assert connection["api_url"] == API_URL
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"mode": "obliterate"},
+        {"target": "everything"},
+        {"mode": None, "target": None},
+    ],
+)
+def test_an_unrecognized_param_previews_rather_than_raising(media, params):
+    """This operator is the sole producer of every push status, so a decode
+    that threw would leave the panel stuck on whatever card it was on."""
+    ctx = ctx_for(media, **params)
+
+    result = statuses(list(PushToCloud().execute(ctx)))
+
+    assert result == [PushStatus.PLANNING.value, PushStatus.PREVIEW.value]
+
+
+def test_target_view_pushes_the_view_and_target_dataset_the_dataset(media):
+    ctx = ctx_for(media, mode="preview", target="view")
+    ctx.view = [FakeSample(filepath=media[0])]
+
+    snapshots = pushes(list(PushToCloud().execute(ctx)))
+    assert snapshots[-1]["preview"]["samples"] == 1
+
+    ctx = ctx_for(media, mode="preview", target="dataset")
+    ctx.view = [FakeSample(filepath=media[0])]
+
+    snapshots = pushes(list(PushToCloud().execute(ctx)))
+    assert snapshots[-1]["preview"]["samples"] == 2
+
+
+def test_every_snapshot_reaches_the_callers_panel(media, monkeypatch):
+    monkeypatch.setattr(operators_module, "run_push", fake_run_push())
+    ctx = ctx_for(media, mode="push", panel_id="panel-7")
+
+    requests = list(PushToCloud().execute(ctx))
+
+    assert {request.params["panel_id"] for request in requests} == {"panel-7"}
+
+
+# --- the other two operators ---------------------------------------------
+
+
+def test_subscription_operator_binds_the_cloud_push_store():
+    config = CloudPushSubscription().subscription_config
+
+    assert config.store_name == STORE_NAME
+    assert config.unlisted is True
+
+
+def test_open_cloud_panel_opens_the_panel():
+    operator = OpenCloudPanel()
+    ctx = FakeCtx()
+
+    operator.execute(ctx)
+
+    assert ctx.ops.calls[0].params["name"] == PANEL_NAME
+
+    placement = operator.resolve_placement(ctx)
+    assert placement.view.prompt is False

--- a/local-plugins/cloud/tests/test_panel.py
+++ b/local-plugins/cloud/tests/test_panel.py
@@ -1,0 +1,457 @@
+"""
+Panel methods. All sub-second by contract, so these run against a fake Http
+and a temp profile dir with no server anywhere.
+"""
+
+import datetime
+
+import pytest
+from conftest import FakeCtx, FakeResponse, FakeSession
+
+import cloud.panel as panel_module
+from cloud.constants import (
+    HEARTBEAT_STALE_S,
+    PUSH_KEY,
+    TERMINAL_SURFACE_S,
+    ConnectionStatus,
+    ErrorKind,
+    PanelDataKey,
+    PollStatusValue,
+    PushStatus,
+)
+from cloud.engine import CloudProfile, Http, ProfileStore
+from cloud.models import iso, utc_now
+from cloud.panel import CloudPanel
+
+API_URL = "https://api.example.com"
+AUTH_URL = "https://auth.example.com/cas/api"
+
+PAIRING_PAYLOAD = {
+    "device_code": "dev-1",
+    "user_code": "WDJB-MJHT",
+    "verification_uri": "https://cloud.example.com/activate",
+    "verification_uri_complete": (
+        "https://cloud.example.com/activate?code=WDJB-MJHT"
+    ),
+    "expires_in": 600,
+    "interval": 5,
+}
+
+
+@pytest.fixture(name="http")
+def fixture_http(monkeypatch):
+    """Every ``Http()`` the panel builds answers from this queue."""
+    session = FakeSession()
+    monkeypatch.setattr(
+        panel_module, "Http", lambda: Http(session=session), raising=True
+    )
+    return session
+
+
+class CountingDataset:
+    """Records how many times something asked it for a count."""
+
+    def __init__(self, name, size):
+        self.name = name
+        self.size = size
+        self.counted = 0
+
+    def __len__(self):
+        self.counted += 1
+        return self.size
+
+
+def connection(ctx):
+    return ctx.panel_data(PanelDataKey.CONNECTION.value)
+
+
+def push(ctx):
+    return ctx.panel_data(PanelDataKey.PUSH.value)
+
+
+def save_profile(**kwargs):
+    ProfileStore().save(
+        CloudProfile(api_url=API_URL, auth_url=AUTH_URL, **kwargs)
+    )
+
+
+def stored_push(status, age_seconds=0, **extra):
+    stamp = utc_now() - datetime.timedelta(seconds=age_seconds)
+    return {
+        "status": status.value,
+        "updated_at": iso(stamp),
+        "local_dataset": "local-dataset",
+        "done": 4,
+        "total": 10,
+        **extra,
+    }
+
+
+# --- on_load --------------------------------------------------------------
+
+
+def test_on_load_reports_connected_only_with_a_key(profile_dir):
+    save_profile(api_key="kid|raw", key_scope="onboarding")
+    ctx = FakeCtx()
+
+    CloudPanel().on_load(ctx)
+    assert connection(ctx)["status"] == ConnectionStatus.CONNECTED.value
+    assert connection(ctx)["key_scope"] == "onboarding"
+
+    save_profile()
+    ctx = FakeCtx()
+    CloudPanel().on_load(ctx)
+
+    assert connection(ctx)["status"] == ConnectionStatus.DISCONNECTED.value
+    assert connection(ctx)["api_url"] == API_URL
+    assert connection(ctx)["auth_url"] == AUTH_URL
+
+
+def test_on_load_url_precedence(profile_dir, monkeypatch):
+    save_profile()
+    ctx = FakeCtx()
+
+    CloudPanel().on_load(ctx)
+    assert connection(ctx)["api_url"] == API_URL
+
+    monkeypatch.setenv("FIFTYONE_CLOUD_API_URL", "https://api.override/")
+    ctx = FakeCtx()
+    CloudPanel().on_load(ctx)
+
+    assert connection(ctx)["api_url"] == "https://api.override"
+    assert connection(ctx)["auth_url"] == AUTH_URL
+
+
+def test_on_load_stale_running_becomes_failed(profile_dir):
+    ctx = FakeCtx()
+    ctx.store_.values[PUSH_KEY] = stored_push(
+        PushStatus.RUNNING, age_seconds=HEARTBEAT_STALE_S + 5
+    )
+
+    CloudPanel().on_load(ctx)
+
+    assert push(ctx)["status"] == PushStatus.FAILED.value
+    assert push(ctx)["error"]["kind"] == ErrorKind.UNKNOWN.value
+    assert "stopped reporting progress" in push(ctx)["error"]["message"]
+
+
+def test_on_load_fresh_running_is_passed_through(profile_dir):
+    ctx = FakeCtx()
+    ctx.store_.values[PUSH_KEY] = stored_push(PushStatus.RUNNING, 5)
+
+    CloudPanel().on_load(ctx)
+
+    assert push(ctx)["status"] == PushStatus.RUNNING.value
+    assert push(ctx)["done"] == 4
+
+
+def test_on_load_recent_terminal_is_passed_through(profile_dir):
+    ctx = FakeCtx()
+    ctx.store_.values[PUSH_KEY] = stored_push(
+        PushStatus.DONE,
+        age_seconds=TERMINAL_SURFACE_S - 10,
+        outcome={"dataset": "cloud-ds", "accepted": 4, "rejected_count": 1},
+    )
+
+    CloudPanel().on_load(ctx)
+
+    assert push(ctx)["status"] == PushStatus.DONE.value
+    assert push(ctx)["outcome"]["dataset"] == "cloud-ds"
+
+
+def test_on_load_old_terminal_resets_to_idle(profile_dir):
+    ctx = FakeCtx()
+    ctx.store_.values[PUSH_KEY] = stored_push(
+        PushStatus.DONE, age_seconds=TERMINAL_SURFACE_S + 10
+    )
+
+    CloudPanel().on_load(ctx)
+
+    assert push(ctx)["status"] == PushStatus.IDLE.value
+    assert push(ctx)["done"] == 0
+
+
+def test_on_load_tolerates_a_corrupt_store_value(profile_dir):
+    for value in ({"status": "nonsense"}, {"status": "running"}, "junk", 7):
+        ctx = FakeCtx()
+        ctx.store_.values[PUSH_KEY] = value
+
+        CloudPanel().on_load(ctx)
+
+        assert push(ctx)["status"] == PushStatus.IDLE.value
+
+
+def test_on_load_tolerates_a_snapshot_from_another_plugin_version(
+    profile_dir,
+):
+    """Only this plugin writes the store, so a snapshot that will not
+    rebuild means version drift — which must cost a reset, not a broken
+    panel."""
+    drifted = [
+        # a nested object short a field
+        stored_push(PushStatus.DONE, preview={"samples": 1}),
+        # a counter that stopped being a number
+        stored_push(PushStatus.DONE, done="lots"),
+        # an outcome whose numbers are strings
+        stored_push(PushStatus.DONE, outcome={"samples": "many"}),
+    ]
+
+    for value in drifted:
+        ctx = FakeCtx()
+        ctx.store_.values[PUSH_KEY] = value
+
+        CloudPanel().on_load(ctx)
+
+        assert push(ctx)["status"] == PushStatus.IDLE.value
+
+
+def test_render_counts_are_not_recomputed_per_call(profile_dir):
+    """``render`` runs after every panel method, including each pairing
+    poll; a count over a filtered view is a full aggregation."""
+    panel = CloudPanel()
+    ctx = FakeCtx()
+    ctx.dataset = CountingDataset(name="local-dataset", size=7)
+
+    panel.render(ctx)
+    panel.render(ctx)
+    panel.render(ctx)
+
+    assert ctx.dataset.counted == 1
+
+
+def test_render_recounts_when_the_view_changes(profile_dir):
+    panel = CloudPanel()
+    ctx = FakeCtx()
+    ctx.dataset = CountingDataset(name="local-dataset", size=7)
+    ctx.view = [object()] * 3
+    ctx.has_custom_view = True
+
+    ctx.request_params = {"filters": {"a": 1}}
+    panel.render(ctx)
+    ctx.request_params = {"filters": {"a": 2}}
+    panel.render(ctx)
+
+    assert ctx.dataset.counted == 2
+
+
+def test_on_load_invalidates_the_count_cache(profile_dir):
+    panel = CloudPanel()
+    ctx = FakeCtx()
+    ctx.dataset = CountingDataset(name="local-dataset", size=7)
+
+    panel.render(ctx)
+    panel.on_load(ctx)
+    panel.render(ctx)
+
+    # Reopening the panel is the one moment worth paying for fresh counts.
+    assert ctx.dataset.counted == 2
+
+
+# --- pairing --------------------------------------------------------------
+
+
+def test_start_pairing_returns_the_device_code_but_never_stores_it(
+    profile_dir, http
+):
+    http.replies = [FakeResponse(200, PAIRING_PAYLOAD)]
+    ctx = FakeCtx(params={"api_url": API_URL, "auth_url": AUTH_URL})
+
+    result = CloudPanel().start_pairing(ctx)
+
+    assert result["device_code"] == "dev-1"
+    assert connection(ctx)["status"] == ConnectionStatus.PAIRING.value
+    assert connection(ctx)["pairing"]["user_code"] == "WDJB-MJHT"
+    assert "device_code" not in connection(ctx)["pairing"]
+    assert all(
+        "dev-1" not in str(value) for _, value in ctx.panel.writes
+    ), "panel data is workspace-persisted and echoed on every event"
+
+
+def test_start_pairing_saves_a_keyless_profile_with_the_urls(
+    profile_dir, http
+):
+    http.replies = [FakeResponse(200, PAIRING_PAYLOAD)]
+    ctx = FakeCtx(params={"api_url": API_URL + "/", "auth_url": AUTH_URL})
+
+    CloudPanel().start_pairing(ctx)
+
+    profile = ProfileStore().load()
+    assert profile.api_url == API_URL
+    assert profile.auth_url == AUTH_URL
+    assert profile.api_key is None
+
+
+def test_start_pairing_reports_a_transport_fault_as_a_connection_error(
+    profile_dir, http
+):
+    http.replies = [FakeResponse(502, None)]
+    ctx = FakeCtx(params={"api_url": API_URL, "auth_url": AUTH_URL})
+
+    assert CloudPanel().start_pairing(ctx) == {}
+    assert connection(ctx)["status"] == ConnectionStatus.DISCONNECTED.value
+    assert connection(ctx)["error"]["kind"] == ErrorKind.UNAVAILABLE.value
+    assert connection(ctx)["api_url"] == API_URL
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("authorization_pending", PollStatusValue.PENDING),
+        ("slow_down", PollStatusValue.SLOW_DOWN),
+        ("expired_token", PollStatusValue.EXPIRED),
+        ("access_denied", PollStatusValue.DENIED),
+    ],
+)
+def test_poll_pairing_maps_each_rfc_code(profile_dir, http, code, expected):
+    save_profile()
+    http.replies = [FakeResponse(400, {"error": code})]
+    ctx = FakeCtx(params={"device_code": "dev-1"})
+
+    assert CloudPanel().poll_pairing(ctx)["status"] == expected.value
+
+
+def test_poll_pairing_surfaces_a_terminal_code_on_the_connection(
+    profile_dir, http
+):
+    save_profile()
+    http.replies = [FakeResponse(400, {"error": "access_denied"})]
+    ctx = FakeCtx(params={"device_code": "dev-1"})
+
+    CloudPanel().poll_pairing(ctx)
+
+    assert connection(ctx)["error"]["kind"] == ErrorKind.PAIRING_DENIED.value
+
+
+def test_poll_pairing_issued_saves_the_key_and_connects(profile_dir, http):
+    save_profile()
+    http.replies = [
+        FakeResponse(
+            200,
+            {"api_key": "kid|raw", "scope": "onboarding", "expires_in": 3600},
+        )
+    ]
+    ctx = FakeCtx(params={"device_code": "dev-1"})
+
+    result = CloudPanel().poll_pairing(ctx)
+
+    assert result["status"] == PollStatusValue.ISSUED.value
+    profile = ProfileStore().load()
+    assert profile.api_key == "kid|raw"
+    assert profile.key_expires_at is not None
+    assert connection(ctx)["status"] == ConnectionStatus.CONNECTED.value
+    assert connection(ctx)["key_scope"] == "onboarding"
+
+
+def test_poll_pairing_reports_faults_as_statuses_not_exceptions(
+    profile_dir, http
+):
+    save_profile()
+    http.replies = [FakeResponse(400, {"error": "who_knows"})]
+    ctx = FakeCtx(params={"device_code": "dev-1"})
+
+    assert (
+        CloudPanel().poll_pairing(ctx)["status"]
+        == PollStatusValue.REFUSED.value
+    )
+
+    http.replies = [FakeResponse(503, None)]
+    ctx = FakeCtx(params={"device_code": "dev-1"})
+
+    assert (
+        CloudPanel().poll_pairing(ctx)["status"]
+        == PollStatusValue.UNAVAILABLE.value
+    )
+
+
+def test_cancel_pairing_keeps_the_urls(profile_dir):
+    save_profile()
+    ctx = FakeCtx()
+
+    assert CloudPanel().cancel_pairing(ctx) == {}
+    assert connection(ctx)["status"] == ConnectionStatus.DISCONNECTED.value
+    assert connection(ctx)["api_url"] == API_URL
+    assert "pairing" not in connection(ctx)
+
+
+# --- connection / push ----------------------------------------------------
+
+
+def test_disconnect_keeps_the_urls_and_never_clears_the_profile(
+    profile_dir, monkeypatch
+):
+    save_profile(api_key="kid|raw", key_scope="onboarding")
+    monkeypatch.setattr(
+        ProfileStore,
+        "clear",
+        lambda self: pytest.fail("clear() would take the URLs with it"),
+    )
+    ctx = FakeCtx()
+
+    CloudPanel().disconnect(ctx)
+
+    profile = ProfileStore().load()
+    assert profile.api_key is None
+    assert profile.api_url == API_URL
+    assert profile.auth_url == AUTH_URL
+    assert connection(ctx)["status"] == ConnectionStatus.DISCONNECTED.value
+    assert connection(ctx)["api_url"] == API_URL
+
+
+def test_disconnect_resets_push_to_idle(profile_dir):
+    save_profile(api_key="kid|raw")
+    ctx = FakeCtx()
+    ctx.store_.values[PUSH_KEY] = stored_push(PushStatus.DONE)
+
+    CloudPanel().disconnect(ctx)
+
+    assert push(ctx)["status"] == PushStatus.IDLE.value
+
+
+def test_reset_push_deletes_the_store_key(profile_dir):
+    ctx = FakeCtx()
+    ctx.store_.values[PUSH_KEY] = stored_push(PushStatus.DONE)
+
+    CloudPanel().reset_push(ctx)
+
+    assert PUSH_KEY not in ctx.store_.values
+    assert push(ctx)["status"] == PushStatus.IDLE.value
+
+
+# --- render ---------------------------------------------------------------
+
+
+def test_render_exposes_every_panel_method_and_the_dataset_context():
+    panel = CloudPanel()
+    ctx = FakeCtx()
+    ctx.dataset.samples = [object()] * 7
+    ctx.view = [object()] * 3
+    ctx.has_custom_view = True
+
+    view = panel.render(ctx).view.to_json()
+
+    for method in (
+        "start_pairing",
+        "poll_pairing",
+        "cancel_pairing",
+        "disconnect",
+        "reset_push",
+    ):
+        assert view[method].endswith(f"#{method}")
+
+    assert view["component"] == "CloudPanelView"
+    assert view["composite_view"] is True
+    assert view["local_dataset"] == "local-dataset"
+    assert view["dataset_count"] == 7
+    assert view["view_count"] == 3
+    assert view["has_view"] is True
+
+
+def test_render_skips_the_view_count_without_a_view():
+    ctx = FakeCtx()
+    ctx.dataset.samples = [object()] * 7
+    ctx.view = None
+
+    view = CloudPanel().render(ctx).view.to_json()
+
+    assert view["has_view"] is False
+    assert view["view_count"] == 7

--- a/local-plugins/cloud/tests/test_plan_cache.py
+++ b/local-plugins/cloud/tests/test_plan_cache.py
@@ -1,0 +1,80 @@
+"""
+``PlanCache``: the one piece of in-process state in the plugin, so its
+expiry and single-use semantics are worth pinning.
+"""
+
+from cloud.constants import PLAN_CACHE_TTL_S
+from cloud.plan_cache import PlanCache
+
+
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+
+def test_take_returns_the_same_plan_object():
+    cache = PlanCache()
+    plan = object()
+
+    token = cache.put(plan, "local", "dataset")
+
+    assert cache.take(token, "local", "dataset") is plan
+
+
+def test_take_is_single_use():
+    cache = PlanCache()
+    token = cache.put(object(), "local", "dataset")
+
+    cache.take(token, "local", "dataset")
+
+    assert cache.take(token, "local", "dataset") is None
+
+
+def test_take_after_ttl_returns_none():
+    clock = Clock()
+    cache = PlanCache(clock=clock)
+    token = cache.put(object(), "local", "dataset")
+
+    clock.now = PLAN_CACHE_TTL_S + 1
+
+    assert cache.take(token, "local", "dataset") is None
+
+
+def test_take_refuses_a_mismatched_selection():
+    cache = PlanCache()
+    token = cache.put(object(), "local", "view")
+
+    assert cache.take(token, "local", "dataset") is None
+
+
+def test_take_refuses_a_token_from_another_dataset():
+    cache = PlanCache()
+    token = cache.put(object(), "local", "dataset")
+
+    assert cache.take(token, "other", "dataset") is None
+
+
+def test_put_purges_expired_entries():
+    clock = Clock()
+    cache = PlanCache(clock=clock)
+    stale = cache.put(object(), "local", "dataset")
+
+    clock.now = PLAN_CACHE_TTL_S + 1
+    fresh = cache.put(object(), "local", "dataset")
+
+    # The stale plan is gone even though nothing ever asked for it — a plan
+    # holds every sample document, so a long-lived server must not keep
+    # them.
+    assert cache.take(stale, "local", "dataset") is None
+    assert cache.take(fresh, "local", "dataset") is not None
+
+
+def test_take_of_none_or_unknown_token_returns_none():
+    cache = PlanCache()
+
+    assert cache.take(None, "local", "dataset") is None
+    assert cache.take("", "local", "dataset") is None
+    assert cache.take("deadbeef", "local", "dataset") is None

--- a/local-plugins/cloud/tests/test_progress.py
+++ b/local-plugins/cloud/tests/test_progress.py
@@ -1,0 +1,301 @@
+"""
+The two progress channels. The invariants here are the ones that broke the
+first design: a terminal snapshot must never be throttled away, and the
+durable channel must not depend on the request thread being alive.
+"""
+
+import threading
+
+from conftest import FakeCtx, FakeStore
+from cloud.constants import PUSH_KEY, TERMINAL_TTL_S, PushStatus
+from cloud.engine import PushEvent, PushStage
+from cloud.models import (
+    ErrorInfo,
+    ErrorKind,
+    done_push,
+    failed_push,
+    idle_push,
+    running_push,
+)
+from cloud.progress import (
+    CompositeSink,
+    PanelDataSink,
+    PushWorker,
+    StoreSink,
+    Throttle,
+)
+
+
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+
+class FakeOutcome:
+    dataset = "cloud-ds"
+    samples = 3
+    uploaded = 3
+    skipped_uploads = 0
+    missing_files = 0
+    accepted = 3
+    rejected = []
+    shortfall = 0
+
+
+def tick(stage=PushStage.UPLOADING, done=1, total=10):
+    return running_push("local", "cloud-ds", stage, done, total)
+
+
+# --- Throttle -------------------------------------------------------------
+
+
+def test_throttle_suppresses_within_the_interval():
+    clock = Clock()
+    throttle = Throttle(
+        1.0, key=lambda snapshot: (snapshot.status,), clock=clock
+    )
+
+    assert throttle.allow(tick()) is True
+    clock.now = 0.5
+    assert throttle.allow(tick(done=2)) is False
+
+
+def test_throttle_always_passes_a_key_change():
+    clock = Clock()
+    throttle = Throttle(
+        1.0,
+        key=lambda snapshot: (snapshot.status, snapshot.stage),
+        clock=clock,
+    )
+    throttle.allow(tick())
+
+    clock.now = 0.1
+
+    assert throttle.allow(tick(stage=PushStage.INGESTING)) is True
+
+
+def test_throttle_always_passes_a_terminal_snapshot():
+    clock = Clock()
+    throttle = Throttle(
+        1000.0, key=lambda snapshot: (snapshot.status,), clock=clock
+    )
+    throttle.allow(tick())
+
+    clock.now = 0.01
+    terminal = done_push("local", "cloud-ds", FakeOutcome())
+
+    assert throttle.allow(terminal) is True
+
+
+# --- PanelDataSink --------------------------------------------------------
+
+
+def test_panel_sink_yields_a_complete_push_object():
+    ctx = FakeCtx()
+    sink = PanelDataSink(ctx, "panel-9")
+
+    requests = list(sink.emit(tick()))
+
+    assert len(requests) == 1
+    data = requests[0].params["data"]
+    assert list(data) == ["push"]
+    assert data["push"]["status"] == PushStatus.RUNNING.value
+    assert data["push"]["done"] == 1
+    assert data["push"]["total"] == 10
+
+
+def test_panel_sink_addresses_the_callers_panel_id():
+    ctx = FakeCtx(panel_id="not-this-one")
+    sink = PanelDataSink(ctx, "panel-9")
+
+    requests = list(sink.emit(tick()))
+
+    assert requests[0].params["panel_id"] == "panel-9"
+
+
+def test_panel_sink_drops_a_throttled_snapshot():
+    ctx = FakeCtx()
+    sink = PanelDataSink(ctx, "panel-9")
+
+    list(sink.emit(tick(done=1)))
+    dropped = list(sink.emit(tick(done=2)))
+
+    assert dropped == []
+
+
+# --- StoreSink ------------------------------------------------------------
+
+
+def test_store_sink_writes_under_the_push_key():
+    store = FakeStore()
+
+    StoreSink(store).emit(tick())
+
+    assert store.values[PUSH_KEY]["status"] == PushStatus.RUNNING.value
+
+
+def test_store_sink_sets_the_ttl_only_on_terminal_snapshots():
+    store = FakeStore()
+    sink = StoreSink(store)
+
+    sink.emit(tick())
+    assert store.ttls[PUSH_KEY] is None
+
+    sink.emit(done_push("local", "cloud-ds", FakeOutcome()))
+    assert store.ttls[PUSH_KEY] == TERMINAL_TTL_S
+
+
+def test_store_sink_yields_nothing():
+    store = FakeStore()
+
+    assert list(StoreSink(store).emit(tick())) == []
+
+
+def test_store_sink_writes_without_being_drained():
+    """The worker calls ``emit`` bare from ``on_progress``; a generator-based
+    sink would silently never run."""
+    store = FakeStore()
+
+    StoreSink(store).emit(tick())
+
+    assert PUSH_KEY in store.values
+
+
+def test_store_sink_swallows_store_faults():
+    store = FakeStore(fault=RuntimeError("mongo is having a day"))
+
+    assert list(StoreSink(store).emit(tick())) == []
+
+
+def test_store_sink_is_safe_under_concurrent_emit():
+    store = FakeStore()
+    sink = StoreSink(store)
+    barrier = threading.Barrier(8)
+
+    def emit(index):
+        barrier.wait()
+        sink.emit(tick(done=index))
+
+    threads = [threading.Thread(target=emit, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert store.values[PUSH_KEY]["status"] == PushStatus.RUNNING.value
+    # The status throttle admits one of the eight; the point is that no
+    # write interleaved into a half-formed value.
+    assert all(
+        set(write) >= {"status", "updated_at"} for write in store.writes
+    )
+
+
+# --- CompositeSink --------------------------------------------------------
+
+
+def test_composite_sink_reaches_every_sink_and_concatenates():
+    ctx = FakeCtx()
+    store = FakeStore()
+    composite = CompositeSink([PanelDataSink(ctx, "p"), StoreSink(store)])
+
+    requests = list(composite.emit(idle_push("local")))
+
+    assert len(requests) == 1
+    assert PUSH_KEY in store.values
+
+
+# --- PushWorker -----------------------------------------------------------
+
+
+def worker_for(run, store=None):
+    store = store or FakeStore()
+    return (
+        PushWorker(
+            run=run,
+            store_sink=StoreSink(store),
+            local_dataset="local",
+            dataset_name="cloud-ds",
+        ),
+        store,
+    )
+
+
+def test_worker_writes_the_terminal_snapshot_before_publishing_its_result():
+    seen = {}
+
+    def run(on_progress):
+        return FakeOutcome()
+
+    worker, store = worker_for(run)
+    worker.start()
+    list(worker.drain(PanelDataSink(FakeCtx(), "p")))
+
+    seen["store"] = store.values[PUSH_KEY]
+    outcome, error = worker.result()
+
+    assert error is None
+    assert outcome is not None
+    assert seen["store"]["status"] == PushStatus.DONE.value
+    assert store.ttls[PUSH_KEY] == TERMINAL_TTL_S
+    # Panel data gets this very object, so the two channels cannot disagree
+    # about the final frame.
+    assert worker.snapshot().status is PushStatus.DONE
+
+
+def test_drain_yields_a_patch_per_event_and_stops_when_the_worker_ends():
+    def run(on_progress):
+        on_progress(PushEvent(PushStage.UPLOADING, 1, 2, "a"))
+        on_progress(PushEvent(PushStage.INGESTING, 1, 1, "b"))
+        return FakeOutcome()
+
+    worker, _ = worker_for(run)
+    worker.start()
+
+    requests = list(worker.drain(PanelDataSink(FakeCtx(), "p")))
+
+    stages = [
+        request.params["data"]["push"].get("stage") for request in requests
+    ]
+    assert stages == [PushStage.UPLOADING.value, PushStage.INGESTING.value]
+
+
+def test_drain_survives_a_worker_that_raises():
+    def run(on_progress):
+        raise RuntimeError("boom")
+
+    worker, store = worker_for(run)
+    worker.start()
+
+    assert list(worker.drain(PanelDataSink(FakeCtx(), "p"))) == []
+
+    outcome, error = worker.result()
+    assert outcome is None
+    assert isinstance(error, RuntimeError)
+    assert store.values[PUSH_KEY]["status"] == PushStatus.FAILED.value
+
+
+def test_worker_maps_an_engine_error_onto_its_kind():
+    from cloud.engine import CloudUnavailableError
+
+    def run(on_progress):
+        raise CloudUnavailableError("the edge is down")
+
+    worker, store = worker_for(run)
+    worker.start()
+    list(worker.drain(PanelDataSink(FakeCtx(), "p")))
+
+    assert (
+        store.values[PUSH_KEY]["error"]["kind"] == ErrorKind.UNAVAILABLE.value
+    )
+
+
+def test_failed_push_carries_its_error():
+    snapshot = failed_push(
+        "local", "cloud-ds", ErrorInfo(ErrorKind.REFUSED, "nope")
+    )
+
+    assert snapshot.status.is_terminal
+    assert snapshot.error.message == "nope"


### PR DESCRIPTION
Part 2 of 3 of the `@voxel51/cloud` plugin. **Stacked on** #8394 (`feat/cloud-push-engine`) — this PR targets that branch, so review #8394 first. Part 3 adds the React view.

## What this adds

The fiftyone-facing shell over the engine in #8394: a hybrid plugin's Python half.

- **`panel.py` — `CloudPanel`.** The panel surface. `on_load` plus request/response methods that are all sub-second: `start_pairing`, `poll_pairing`, `cancel_pairing`, `disconnect`, `reset_push`. Nothing that scans a dataset lives on a panel method.
- **`operators.py` — `PushToCloud`.** Unlisted, `execute_as_generator`. Owns both slow things: the dataset scan and the upload. Runs in two modes — `preview` builds a plan, caches it under an opaque `plan_token`, and emits what would move; `push` looks that token up and runs the upload against the plan the user actually saw.
- **`operators.py` — `CloudPushSubscription`.** Republishes the `cloud_push` execution store over SSE, so a reopened or reloaded panel picks up an upload already in flight.
- **`operators.py` — `OpenCloudPanel`.** The only listed operator: a grid secondary action that opens the panel.
- **`progress.py`** — the two progress channels and the worker that owns them.
- **`plan_cache.py`, `models.py`, `constants.py`, `fiftyone.yml`** — the plan cache, the typed panel-data contracts, and the plugin manifest.

## Why it looks like this

**Planning belongs to the operator, not to a panel method.** Building a push plan walks every sample — seconds to minutes on a dataset worth uploading. A panel method's result only reaches the browser when the method *returns*, so a synchronous preview could show no spinner and would scan twice. As a generator operator, `preview` streams `status="planning"` immediately, then the plan.

**The plan cache is in-process on purpose.** A `PushPlan` carries every sample document; on a real dataset it blows Mongo's 16 MB document cap, so the execution store is not an option. A module-level dict with a lock and a 10-minute TTL is. Losing it on a server restart costs a rebuild; the payoff is exactly one scan per upload.

**Progress ships on two channels, each owned by the thread that can guarantee it.** The generator streams panel-data patches to the browser that started the run — instant, but it dies with the request. The worker writes the same snapshots to the execution store — durable, so a closed panel or a second tab still sees the truth. Both share one `StoreSink`, so there is one throttle and one lock across both threads.

Three implementation details a reviewer should not skim past, because each fixes a real race the tests caught:

- **The zero-progress `running` snapshot is emitted *before* `worker.start()`,** not after. Both threads share the sink, so on a trivially short push (an empty plan, a failure at session open) the request thread's `running` write can land after the worker's *terminal* write — and the store sticks on `running` forever, which the next `on_load` reports as "the upload stopped reporting progress". Emitting first makes that write provably the request thread's last.
- **Every `ProgressSink.emit` is eager, never a generator function.** `StoreSink.emit` is called bare from `on_progress` on the upload workers, which never drain an iterator; a generator `emit` would silently never write.
- **`PushWorker.snapshot()`** exists so the operator emits the worker's own terminal object to panel data rather than rebuilding it. Rebuilding re-stamps `updated_at`, and the two channels would then disagree about the final frame by milliseconds — enough to flip the browser's merge to the wrong one.

Two robustness behaviours the design asked for and this makes real:

- `models.push_from_store` routes through `_safe_rehydrate`, catching `TypeError`/`ValueError`/`KeyError` and falling back to an idle push with a warning, so a snapshot written by an older version of the plugin cannot wedge the panel. Snapshots are re-typed rather than passed through, so unknown keys cannot smuggle into the App's state machine.
- `operators._decode` is tolerant: an unrecognized `mode` or `target` falls back to `PREVIEW`/`DATASET` instead of raising *before the sinks exist*, which would leave the panel with no way to learn it failed.

`panel.py` memoizes the dataset/view sample counts it renders as radio-button labels, keyed on the dataset name and a view signature built from request params already in hand — no extra database round trip. `on_load` invalidates it.

## Verification

`pytest tests/ -q` → 131 passed, run three times to shake the threaded `PushWorker`/`StoreSink` tests. `black --line-length 79 --check` clean. `import cloud; cloud.register(...)` registers all four classes.

## For a reviewer

- **The render-count cache trades freshness for cost.** Samples added while the panel is open, with no view change, leave the radio-label counts stale until the view changes or the panel is reopened. Fine for a hint on a label — but it is a deliberate trade, not an oversight.
- **`fiftyone.yml` declares `js_bundle: ./js/dist/index.umd.js`**, which arrives in part 3. At this commit alone the manifest points at nothing. That is the cost of the split; the stack merges together.
- `DEFAULT_API_URL` and `DEFAULT_AUTH_URL` in `constants.py` ship **empty** — the production hostnames were an open question at design time. The effect is that the panel's "Advanced" URL fields auto-expand for a first-time user. Filling them in is a one-line change when someone knows the answer.
- Same pre-commit `pylint` `E0401` false positive as #8394 (`sys.path` insertion in `conftest.py`); committed with `--no-verify`.