### PR TITLE
bump version to 1.23.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Installs FiftyOne.
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.22.0"
+VERSION = "1.23.0"
 
 
 def get_version():


### PR DESCRIPTION
Advance `main` to the next dev version now that `release/v1.22.0` is cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version from 1.22.0 to 1.23.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->