### PR TITLE
Retry a custom grid renderer after a reload

### DIFF
--- a/app/packages/core/src/components/DatasetGridRendererFailover.tsx
+++ b/app/packages/core/src/components/DatasetGridRendererFailover.tsx
@@ -27,6 +27,10 @@ export const DatasetGridRendererFailoverReload = () => {
     }
 
     if (currentSubscription === forcedSubscription) {
+      // The reload has landed, so the failure has done its job. Spending it
+      // here is what lets the next load retry the custom renderer instead of
+      // stranding the user on the built-in one until they open a new tab.
+      fos.consumeGridCustomRendererFailover();
       return;
     }
 
@@ -63,8 +67,8 @@ export const DatasetGridRendererFailoverBanner = () => {
       {gridRendererFailover.failure?.datasetName
         ? ` while rendering "${gridRendererFailover.failure.datasetName}"`
         : ""}{" "}
-      so FiftyOne switched this dataset to the built-in grid renderer for the
-      rest of this browser session.
+      so FiftyOne switched this dataset to the built-in grid renderer. Reload
+      the page to try the custom renderer again.
     </Alert>
   );
 };

--- a/app/packages/state/src/gridCustomRendererFailover.test.tsx
+++ b/app/packages/state/src/gridCustomRendererFailover.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetGridCustomRendererFailoverForTests,
+  consumeGridCustomRendererFailover,
   dismissGridCustomRendererFailoverBanner,
   getGridCustomRendererFailover,
   isGridCustomRendererFailOpen,
@@ -101,5 +102,35 @@ describe("gridCustomRendererFailover", () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  // Re-importing the module is a page load: it re-reads sessionStorage, which
+  // is what survives a refresh and Chrome's tab restore.
+  it("keeps a failure through the reload it triggered", async () => {
+    markGridCustomRendererFailed({
+      datasetName: "lerobot",
+      rendererName: "EpisodeRenderer",
+    });
+
+    vi.resetModules();
+    const nextLoad = await import("./gridCustomRendererFailover");
+
+    expect(nextLoad.isGridCustomRendererFailOpen("lerobot")).toBe(true);
+  });
+
+  it("retries the renderer on the load after that one", async () => {
+    markGridCustomRendererFailed({
+      datasetName: "lerobot",
+      rendererName: "EpisodeRenderer",
+    });
+    consumeGridCustomRendererFailover();
+
+    // The reload it triggered is this load, so it still holds here.
+    expect(isGridCustomRendererFailOpen("lerobot")).toBe(true);
+
+    vi.resetModules();
+    const nextLoad = await import("./gridCustomRendererFailover");
+
+    expect(nextLoad.isGridCustomRendererFailOpen("lerobot")).toBe(false);
   });
 });

--- a/app/packages/state/src/gridCustomRendererFailover.ts
+++ b/app/packages/state/src/gridCustomRendererFailover.ts
@@ -1,9 +1,10 @@
 /**
  * @fileoverview
  *
- * If a custom grid renderer throws, we mark that dataset as fail-open for the
- * rest of the browser session, reload onto a fresh synced subscription, and
- * then keep that dataset on the built-in grid renderer.
+ * If a custom grid renderer throws, we mark that dataset as fail-open, reload
+ * onto a fresh synced subscription, and then keep that dataset on the built-in
+ * grid renderer. The mark lasts until the next page load, so reloading retries
+ * the renderer rather than stranding the user on the built-in one.
  *
  * Implementation-wise, this is a tiny external store backed by
  * `sessionStorage`: it tracks failed datasets locally, exposes a forced
@@ -18,14 +19,18 @@ export type GridCustomRendererFailure = {
   rendererName: string;
   failedAt: number;
   errorMessage?: string;
+  // Set once the reload this failure triggered has landed. Reloading is the
+  // user's way of saying "try again", so a failure only survives the one
+  // reload it caused.
+  consumed?: boolean;
 };
 
 type GridCustomRendererFailoverSnapshot = {
   // Per-dataset UI state for the warning banner. Dismissing a banner should
   // not clear fail-open mode, so this is tracked separately from `failures`.
   dismissedBanners: Record<string, boolean>;
-  // Per-dataset fail-open decisions for this browser session. If a dataset is
-  // present here, its custom grid renderer stays disabled until the tab ends.
+  // Per-dataset fail-open decisions. If a dataset is present here, its custom
+  // grid renderer stays disabled until the next page load.
   failures: Record<string, GridCustomRendererFailure>;
 };
 
@@ -134,7 +139,7 @@ const getForcedSubscription = (
  * accepted so an existing tab can seamlessly upgrade to the dataset-scoped
  * model without manual storage clearing.
  */
-const readSnapshot = (): GridCustomRendererFailoverSnapshot => {
+const readStoredSnapshot = (): GridCustomRendererFailoverSnapshot => {
   if (!canUseSessionStorage()) {
     return createEmptySnapshot();
   }
@@ -166,6 +171,35 @@ const readSnapshot = (): GridCustomRendererFailoverSnapshot => {
     return createEmptySnapshot();
   }
 };
+
+/**
+ * Drops failures that already served their reload, so the renderer is retried
+ * rather than left disabled with no way back: `sessionStorage` outlives a hard
+ * refresh, and Chrome restores it on tab restore, so a kept failure survives
+ * even quitting the browser and only a brand new tab clears it.
+ */
+const dropSpentFailures = (
+  stored: GridCustomRendererFailoverSnapshot,
+): GridCustomRendererFailoverSnapshot => {
+  const failures: Record<string, GridCustomRendererFailure> = {};
+  const dismissedBanners: Record<string, boolean> = {};
+
+  for (const [datasetName, failure] of Object.entries(stored.failures)) {
+    if (failure.consumed) {
+      continue;
+    }
+
+    failures[datasetName] = failure;
+    if (stored.dismissedBanners[datasetName]) {
+      dismissedBanners[datasetName] = true;
+    }
+  }
+
+  return { dismissedBanners, failures };
+};
+
+const readSnapshot = (): GridCustomRendererFailoverSnapshot =>
+  dropSpentFailures(readStoredSnapshot());
 
 let snapshot = readSnapshot();
 const listeners = new Set<() => void>();
@@ -225,6 +259,30 @@ export const getGridCustomRendererFailoverSnapshot = () => snapshot;
  */
 export const getGridCustomRendererFailoverForcedSubscription = () =>
   getForcedSubscription(snapshot.failures);
+
+/**
+ * Records that the reload these failures triggered has landed. They stay in
+ * force for this page load; the next one drops them and retries the renderer.
+ */
+export const consumeGridCustomRendererFailover = () => {
+  const entries = Object.entries(snapshot.failures);
+  if (
+    entries.length === 0 ||
+    entries.every(([, failure]) => failure.consumed)
+  ) {
+    return;
+  }
+
+  replaceSnapshot({
+    dismissedBanners: snapshot.dismissedBanners,
+    failures: Object.fromEntries(
+      entries.map(([datasetName, failure]) => [
+        datasetName,
+        { ...failure, consumed: true },
+      ]),
+    ),
+  });
+};
 
 /** Returns the recorded failure for a dataset in the current browser session. */
 export const getGridCustomRendererFailover = (


### PR DESCRIPTION

<!--
Community contributors: target the `community` branch, not `main`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/main/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

<!--
Use keywords to link issues. Closes/Fixes will auto-close the issue when this PR merges.
- Closes #issue-number
- Fixes #issue-number
Learn more about linking PRs to an issue on GitHub:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

Leave empty or write "No related issues to link" if no related issues exist.
-->

## 📋 What changes are proposed in this pull request?

  When a custom grid renderer throws, the dataset is marked fail-open and the
  page reloads onto the built-in renderer. The mark was never cleared, and
  because it lives in `sessionStorage` it survived a hard refresh and Chrome's
  tab restore — only a new tab recovered. A crashed renderer therefore left the
  grid blank with no discoverable way back, and the banner described the state
  as permanent.

  The mark is now consumed by the reload it triggers: it is set on failure, spent
  once `currentSubscription === forcedSubscription`, and dropped on read. A reload
  retries the custom renderer. A renderer that still throws falls back again after
  one reload, so there is no loop. The banner now says to reload rather than
  stating the renderer is disabled for the session.



## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom renderer failures now trigger a page reload prompt, allowing users to retry the custom renderer on the next load.
  * Renderer failures persist through the reload that triggered them, then clear afterward so subsequent loads can retry the renderer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4021
<!-- enterprise-sync-pr:end -->