### PR TITLE
Load a dataset's temporal tags once instead of once per tile

### DIFF
--- a/app/packages/multimodal/src/grid-overlay/temporal-tag-interval-source.test.tsx
+++ b/app/packages/multimodal/src/grid-overlay/temporal-tag-interval-source.test.tsx
@@ -8,7 +8,7 @@ const state = {
   fieldActive: false,
 };
 
-const useSampleRendererTemporalTags = vi.fn();
+const useSampleTemporalTagsFromDataset = vi.fn();
 
 vi.mock("@fiftyone/state", () => ({
   useActiveTemporalTagFilterValues: () => state.activeValues,
@@ -17,8 +17,8 @@ vi.mock("@fiftyone/state", () => ({
 }));
 
 vi.mock("../temporal-tags", () => ({
-  useSampleRendererTemporalTags: (ctx: unknown) =>
-    useSampleRendererTemporalTags(ctx),
+  useSampleTemporalTagsFromDataset: (datasetId: unknown, sampleId: unknown) =>
+    useSampleTemporalTagsFromDataset(datasetId, sampleId),
 }));
 
 const { temporalTagIntervalSource } =
@@ -57,8 +57,8 @@ function contribute(): EpisodeIntervalContribution {
 beforeEach(() => {
   state.activeValues = [];
   state.fieldActive = false;
-  useSampleRendererTemporalTags.mockReset();
-  useSampleRendererTemporalTags.mockReturnValue({ temporalTags: [] });
+  useSampleTemporalTagsFromDataset.mockReset();
+  useSampleTemporalTagsFromDataset.mockReturnValue([]);
 });
 
 describe("temporalTagIntervalSource", () => {
@@ -73,14 +73,15 @@ describe("temporalTagIntervalSource", () => {
     const contribution = contribute();
 
     expect(contribution.intervals).toEqual([]);
-    expect(useSampleRendererTemporalTags).not.toHaveBeenCalled();
+    expect(useSampleTemporalTagsFromDataset).not.toHaveBeenCalled();
   });
 
   it("contributes every tag when the field is enabled", () => {
     state.fieldActive = true;
-    useSampleRendererTemporalTags.mockReturnValue({
-      temporalTags: [tag("a", 0, 1), tag("b", 2, 3)],
-    });
+    useSampleTemporalTagsFromDataset.mockReturnValue([
+      tag("a", 0, 1),
+      tag("b", 2, 3),
+    ]);
 
     const contribution = contribute();
 
@@ -92,9 +93,10 @@ describe("temporalTagIntervalSource", () => {
 
   it("narrows to the filtered values when only a filter is active", () => {
     state.activeValues = ["a"];
-    useSampleRendererTemporalTags.mockReturnValue({
-      temporalTags: [tag("a", 0, 1), tag("b", 2, 3)],
-    });
+    useSampleTemporalTagsFromDataset.mockReturnValue([
+      tag("a", 0, 1),
+      tag("b", 2, 3),
+    ]);
 
     const contribution = contribute();
 
@@ -103,9 +105,7 @@ describe("temporalTagIntervalSource", () => {
 
   it("carries the tag's own colour and span", () => {
     state.activeValues = ["a"];
-    useSampleRendererTemporalTags.mockReturnValue({
-      temporalTags: [tag("a", 1, 2)],
-    });
+    useSampleTemporalTagsFromDataset.mockReturnValue([tag("a", 1, 2)]);
 
     expect(contribute().intervals[0]).toMatchObject({
       sourceId: temporalTagIntervalSource.id,
@@ -118,9 +118,10 @@ describe("temporalTagIntervalSource", () => {
 
   it("groups repeated occurrences of one tag as separate intervals", () => {
     state.activeValues = ["a"];
-    useSampleRendererTemporalTags.mockReturnValue({
-      temporalTags: [tag("a", 0, 1), tag("a", 5, 6)],
-    });
+    useSampleTemporalTagsFromDataset.mockReturnValue([
+      tag("a", 0, 1),
+      tag("a", 5, 6),
+    ]);
 
     expect(contribute().intervals).toHaveLength(2);
   });
@@ -129,18 +130,17 @@ describe("temporalTagIntervalSource", () => {
     // Enabling the pseudo-field shows the lane; it is not a request to pin
     // every tag in the modal.
     state.fieldActive = true;
-    useSampleRendererTemporalTags.mockReturnValue({
-      temporalTags: [tag("a", 0, 1), tag("b", 2, 3)],
-    });
+    useSampleTemporalTagsFromDataset.mockReturnValue([
+      tag("a", 0, 1),
+      tag("b", 2, 3),
+    ]);
 
     expect(contribute().pinnedRowKeys).toEqual([]);
   });
 
   it("pins the filtered values", () => {
     state.activeValues = ["a", "b"];
-    useSampleRendererTemporalTags.mockReturnValue({
-      temporalTags: [tag("a", 0, 1)],
-    });
+    useSampleTemporalTagsFromDataset.mockReturnValue([tag("a", 0, 1)]);
 
     expect(contribute().pinnedRowKeys).toEqual(["a", "b"]);
   });
@@ -148,9 +148,10 @@ describe("temporalTagIntervalSource", () => {
   it("reports the extent of every tag, not just the shown ones", () => {
     // Otherwise narrowing a filter would rescale the tile's time axis.
     state.activeValues = ["a"];
-    useSampleRendererTemporalTags.mockReturnValue({
-      temporalTags: [tag("a", 0, 1), tag("b", 8, 9)],
-    });
+    useSampleTemporalTagsFromDataset.mockReturnValue([
+      tag("a", 0, 1),
+      tag("b", 8, 9),
+    ]);
 
     expect(contribute().domainEndNs).toBe(9 * NS);
   });

--- a/app/packages/multimodal/src/grid-overlay/temporal-tag-interval-source.tsx
+++ b/app/packages/multimodal/src/grid-overlay/temporal-tag-interval-source.tsx
@@ -11,7 +11,7 @@ import type {
   EpisodeIntervalSourceProps,
 } from "../extensions/episode-intervals";
 import type { TemporalTag } from "../temporal-tags";
-import { useSampleRendererTemporalTags } from "../temporal-tags";
+import { useSampleTemporalTagsFromDataset } from "../temporal-tags";
 
 const SOURCE_ID = "fiftyone:temporal-tags";
 const INACTIVE: EpisodeIntervalContribution = { intervals: [] };
@@ -21,8 +21,7 @@ const INACTIVE: EpisodeIntervalContribution = { intervals: [] };
  * pseudo-field contributes every interval on the sample, matching the
  * sample-tags parent checkbox; selecting child filter values narrows it to
  * those values. Contributes nothing, and fetches nothing, when neither is
- * active — this outer gate is what keeps an unfiltered grid from issuing a tag
- * request per tile.
+ * active.
  */
 const TemporalTagIntervalSourceComponent: React.FC<
   EpisodeIntervalSourceProps
@@ -49,7 +48,12 @@ const TemporalTagIntervals: React.FC<
     readonly showAll: boolean;
   }
 > = ({ activeValues, children, ctx, showAll }) => {
-  const { temporalTags } = useSampleRendererTemporalTags(ctx);
+  // The grid mounts one of these per tile, so the tags come from the dataset's
+  // single shared load rather than a fetch per sample
+  const temporalTags = useSampleTemporalTagsFromDataset(
+    ctx.dataset.datasetId,
+    ctx.sample.sample._id,
+  );
   const colorForTag = useTemporalTagColor();
 
   const contribution = useMemo<EpisodeIntervalContribution>(() => {

--- a/app/packages/multimodal/src/temporal-tags/dataset-tags.ts
+++ b/app/packages/multimodal/src/temporal-tags/dataset-tags.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { createTemporalTagsClient } from "./client";
+import type { TemporalTag, TemporalTagsClient } from "./types";
+
+type TagsBySample = ReadonlyMap<string, readonly TemporalTag[]>;
+
+const EMPTY: TagsBySample = new Map();
+const NO_TAGS: readonly TemporalTag[] = [];
+
+type Entry = {
+  bySample: TagsBySample;
+  generation: number;
+  loading: boolean;
+};
+
+const entries = new Map<string, Entry>();
+const listeners = new Set<() => void>();
+let defaultClient: TemporalTagsClient | undefined;
+
+function getDefaultClient() {
+  defaultClient ??= createTemporalTagsClient();
+
+  return defaultClient;
+}
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function entryFor(datasetId: string): Entry {
+  let entry = entries.get(datasetId);
+  if (!entry) {
+    entry = { bySample: EMPTY, generation: 0, loading: false };
+    entries.set(datasetId, entry);
+  }
+
+  return entry;
+}
+
+function groupBySample(tags: readonly TemporalTag[]): TagsBySample {
+  const bySample = new Map<string, TemporalTag[]>();
+  for (const tag of tags) {
+    const group = bySample.get(tag.sampleId);
+    if (group) group.push(tag);
+    else bySample.set(tag.sampleId, [tag]);
+  }
+
+  return bySample;
+}
+
+function load(client: TemporalTagsClient, datasetId: string) {
+  const entry = entryFor(datasetId);
+  if (entry.loading) return;
+
+  entry.loading = true;
+  const generation = ++entry.generation;
+  client
+    .listDatasetTemporalTags({ datasetId })
+    .then((tags) => {
+      // an invalidation bumped past this response, so it is already stale
+      if (entry.generation !== generation) return;
+      entry.bySample = groupBySample(tags);
+      entry.loading = false;
+      emit();
+    })
+    .catch(() => {
+      if (entry.generation !== generation) return;
+      entry.loading = false;
+      emit();
+    });
+}
+
+/**
+ * Refetches a dataset's tags after a mutation, so the grid reflects what the
+ * modal just changed.
+ */
+export function invalidateDatasetTemporalTags(
+  datasetId: string | undefined,
+  client?: TemporalTagsClient,
+) {
+  if (!datasetId) return;
+
+  const entry = entries.get(datasetId);
+  if (!entry) return;
+
+  // past any in-flight response, which would otherwise land as fresh
+  entry.generation += 1;
+  entry.loading = false;
+  load(client ?? getDefaultClient(), datasetId);
+}
+
+/**
+ * Every temporal tag on a dataset, grouped by sample.
+ *
+ * One request per dataset, shared by every subscriber: the grid renders a
+ * source per tile, and a tile resolving its own tags over the network would
+ * put one request per tile on the wire.
+ */
+export function useDatasetTemporalTags(
+  datasetId: string | undefined,
+  client?: TemporalTagsClient,
+): TagsBySample {
+  const tagsClient = client ?? getDefaultClient();
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    listeners.add(onStoreChange);
+
+    return () => {
+      listeners.delete(onStoreChange);
+    };
+  }, []);
+  const getSnapshot = useCallback(
+    () => (datasetId ? (entries.get(datasetId)?.bySample ?? EMPTY) : EMPTY),
+    [datasetId],
+  );
+
+  useEffect(() => {
+    if (datasetId) load(tagsClient, datasetId);
+  }, [datasetId, tagsClient]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** One sample's tags, read from the dataset's shared load. */
+export function useSampleTemporalTagsFromDataset(
+  datasetId: string | undefined,
+  sampleId: string | undefined,
+): readonly TemporalTag[] {
+  const bySample = useDatasetTemporalTags(datasetId);
+
+  return (sampleId ? bySample.get(sampleId) : undefined) ?? NO_TAGS;
+}

--- a/app/packages/multimodal/src/temporal-tags/hooks.ts
+++ b/app/packages/multimodal/src/temporal-tags/hooks.ts
@@ -2,6 +2,7 @@ import type { SampleRendererProps } from "@fiftyone/plugins";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { errorMessage } from "../utils/errors";
 import { createTemporalTagsClient } from "./client";
+import { invalidateDatasetTemporalTags } from "./dataset-tags";
 import type {
   TemporalTag,
   TemporalTagCreate,
@@ -107,6 +108,7 @@ export function useSampleTemporalTags({
         ...ids,
         temporalTags,
       });
+      invalidateDatasetTemporalTags(datasetId, temporalTagsClient);
       await reload();
 
       return created;
@@ -122,6 +124,7 @@ export function useSampleTemporalTags({
         temporalTagId,
         update,
       });
+      invalidateDatasetTemporalTags(datasetId, temporalTagsClient);
       await reload();
 
       return updated;
@@ -136,6 +139,7 @@ export function useSampleTemporalTags({
         ...ids,
         ids: idsToDelete,
       });
+      invalidateDatasetTemporalTags(datasetId, temporalTagsClient);
       await reload();
 
       return deleted;
@@ -150,6 +154,7 @@ export function useSampleTemporalTags({
         ...ids,
         filter: clearFilter,
       });
+      invalidateDatasetTemporalTags(datasetId, temporalTagsClient);
       await reload();
 
       return deleted;

--- a/app/packages/multimodal/src/temporal-tags/index.ts
+++ b/app/packages/multimodal/src/temporal-tags/index.ts
@@ -4,6 +4,11 @@
 export { createTemporalTagsClient } from "./client";
 export { TEMPORAL_TAG_INDEX_TYPE } from "./types";
 export { useSampleRendererTemporalTags, useSampleTemporalTags } from "./hooks";
+export {
+  invalidateDatasetTemporalTags,
+  useDatasetTemporalTags,
+  useSampleTemporalTagsFromDataset,
+} from "./dataset-tags";
 export type { CreateTemporalTagsClientOptions } from "./client";
 export type {
   CountDatasetTemporalTagsRequest,

--- a/app/packages/multimodal/src/views/episode/shell/PlaybackShell.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/PlaybackShell.tsx
@@ -92,6 +92,8 @@ export interface PlaybackShellProps {
   tracks?: Track[];
   /** Track ids that should start pinned to the timeline. */
   defaultPinnedTrackIds?: string[];
+  /** Scope under which the user's pin choices survive closing the modal. */
+  pinPersistKey?: string;
   /** Per-row behavior composed from shared and registered timeline sources. */
   decorateTrack?: TemporalTagTimelineProps["decorateTrack"];
   /** Ruler overlay composed from registered timeline sources. */
@@ -258,6 +260,7 @@ const PlaybackShell: React.FC<PlaybackShellProps> = ({
   timelineTrailingActions,
   tracks,
   defaultPinnedTrackIds,
+  pinPersistKey,
   decorateTrack,
   timelineRulerOverlay,
   initialTiles,
@@ -300,6 +303,7 @@ const PlaybackShell: React.FC<PlaybackShellProps> = ({
         tracks={tracks}
         initialPinnedIds={defaultPinnedTrackIds}
         autoPinNewTracks={false}
+        persistKey={pinPersistKey}
       >
         <SceneInventoryProvider sources={sceneSources}>
           <TilingProvider

--- a/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
+++ b/app/packages/multimodal/src/views/episode/shell/SourcePlayback.tsx
@@ -456,6 +456,10 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
   const effectiveLayoutScopeKey =
     layoutScopeKey ??
     (source ? `episode-source:${source.sourceId}` : undefined);
+  // Pins are a user choice, so they outlive the modal that made them
+  const pinPersistKey = effectiveLayoutScopeKey
+    ? `episode-pins:${effectiveLayoutScopeKey}`
+    : undefined;
   const cameraViewStateScopeKey =
     cameraScopeKey(effectiveLayoutScopeKey, cameraPreferenceField) ??
     effectiveLayoutScopeKey;
@@ -666,6 +670,7 @@ const SourcePlaybackContent: React.FC<SourcePlaybackProps> = ({
                                       ? [...defaultPinnedTrackIds]
                                       : undefined
                                   }
+                                  pinPersistKey={pinPersistKey}
                                   onTagDelete={onTagDelete}
                                   leftSidebar={
                                     <SettingsSidebar


### PR DESCRIPTION


## 🔗 Related Issues

<img width="2457" height="923" alt="image" src="https://github.com/user-attachments/assets/2ecdcf8b-8332-4986-8805-f5c73020794e" />

## 📋 What changes are proposed in this pull request?

The grid mounts an episode-interval source per tile, and each one fetched its own sample's tags, so enabling the temporal-tags field issued a request per tile -- 1,227 on a dataset that size, queuing behind everything else the page needed. Tiles now read from one shared dataset-level load, which modal mutations invalidate.

Pin state was also lost whenever the modal closed: TrackProvider supports persistence but PlaybackShell never passed a key, so pins lived only in component state.

## 🧪 How is this patch tested? If it is not, please explain why.

<!--
Describe the tests you ran or wrote to verify your changes. Include:
- New or updated unit/integration tests
- Manual testing steps performed
- Why tests are not applicable (if skipped)
-->

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Temporal tags are now shared across dataset samples, improving consistency when viewing related data.
  - Changes to temporal tags automatically refresh associated dataset and sample views.
  - Pinned timeline tracks can now persist across playback modal sessions within the same layout scope.
- **Bug Fixes**
  - Improved temporal-tag loading and caching to prevent duplicate requests and avoid displaying outdated results after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4023
<!-- enterprise-sync-pr:end -->