### PR TITLE
Keep an audio tile on its own topic across sample navigation

### DIFF
--- a/app/packages/multimodal/src/views/episode/audio/AudioTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/audio/AudioTile.test.tsx
@@ -5,7 +5,12 @@ const mocks = vi.hoisted(() => ({
   setTileTitle: vi.fn(),
   setHeaderExtra: vi.fn(),
   registerAudioTrack: vi.fn(() => vi.fn()),
-  sources: [] as Array<{ id: string; label: string; type: string }>,
+  sources: [] as Array<{
+    id: string;
+    label: string;
+    sourceName: string;
+    type: string;
+  }>,
   waveformTracks: [] as Array<{ pyramid: unknown }>,
   pcmResult: {
     waveformPeaks: null as unknown,
@@ -67,6 +72,9 @@ vi.mock("./WaveformSurface", () => ({
   ),
 }));
 
+import { semanticSourceKey } from "../settings/semantic-source";
+import { updateSidebarPreferences } from "../settings/sidebar-preferences";
+import { SidebarPreferencesProvider } from "../settings/sidebar-preferences-context";
 import AudioTile from "./AudioTile";
 
 describe("AudioTile", () => {
@@ -97,7 +105,9 @@ describe("AudioTile", () => {
   });
 
   it("labels the waveform from a real source when one is available, without registering a placeholder", () => {
-    mocks.sources = [{ id: "topic-1", label: "Mic 1", type: "audio" }];
+    mocks.sources = [
+      { id: "topic-1", label: "Mic 1", sourceName: "/mic_1", type: "audio" },
+    ];
     render(<AudioTile />);
     // Query by testid, not a CSS-module class: those are hashed in a real
     // build, so `.metadata` matches nothing outside the local dev config.
@@ -108,7 +118,9 @@ describe("AudioTile", () => {
   });
 
   it("shows a decoding status while a real source's PCM hasn't resolved yet", () => {
-    mocks.sources = [{ id: "topic-1", label: "Mic 1", type: "audio" }];
+    mocks.sources = [
+      { id: "topic-1", label: "Mic 1", sourceName: "/mic_1", type: "audio" },
+    ];
     mocks.pcmResult = {
       waveformPeaks: null,
       hasAudio: false,
@@ -119,7 +131,9 @@ describe("AudioTile", () => {
   });
 
   it("shows an unsupported-codec status when the browser cannot decode it", () => {
-    mocks.sources = [{ id: "topic-1", label: "Mic 1", type: "audio" }];
+    mocks.sources = [
+      { id: "topic-1", label: "Mic 1", sourceName: "/mic_1", type: "audio" },
+    ];
     mocks.pcmResult = {
       waveformPeaks: null,
       hasAudio: true,
@@ -132,7 +146,9 @@ describe("AudioTile", () => {
   });
 
   it("uses the real decoded peaks once ready, instead of the synthetic placeholder", () => {
-    mocks.sources = [{ id: "topic-1", label: "Mic 1", type: "audio" }];
+    mocks.sources = [
+      { id: "topic-1", label: "Mic 1", sourceName: "/mic_1", type: "audio" },
+    ];
     const realPeaks = [{ levels: [], samplesPerPeak: 1, sampleRate: 1 }];
     mocks.pcmResult = {
       waveformPeaks: realPeaks,
@@ -144,5 +160,109 @@ describe("AudioTile", () => {
     // Asserting the caption alone would still pass if the tile kept
     // feeding the synthetic placeholder to the waveform.
     expect(mocks.waveformTracks[0]?.pyramid).toBe(realPeaks[0]);
+  });
+
+  // Runtime source ids are positional and get reassigned per recording, and
+  // the playback shell stays mounted across sample navigation — so the tile
+  // has to re-resolve from its persisted semantic key rather than trusting
+  // the id it bound at mount.
+  describe("across sample navigation", () => {
+    const SCOPE = "dataset-1";
+    const micFront = { label: "Mic Front", sourceName: "/mic_front" };
+    const micRear = { label: "Mic Rear", sourceName: "/mic_rear" };
+    const audio = (
+      id: string,
+      source: { label: string; sourceName: string },
+    ) => ({ id, type: "audio", ...source });
+
+    afterEach(() => {
+      globalThis.localStorage.clear();
+    });
+
+    const renderScoped = (
+      sources: ReturnType<typeof audio>[],
+      initialSourceId?: string,
+    ) => {
+      mocks.sources = sources;
+      return render(
+        <SidebarPreferencesProvider scopeKey={SCOPE} sources={sources}>
+          <AudioTile initialSourceId={initialSourceId} />
+        </SidebarPreferencesProvider>,
+      );
+    };
+
+    const headerLabel = () =>
+      screen.getByTestId("audio-tile-metadata").textContent ?? "";
+
+    it("follows its persisted source into the next sample even when the runtime ids move", () => {
+      updateSidebarPreferences(SCOPE, (current) => ({
+        ...current,
+        tiles: {
+          ...current.tiles,
+          "audio-tile-1": {
+            audioSourceKey: semanticSourceKey({
+              sourceName: micRear.sourceName,
+              type: "audio",
+            }),
+          },
+        },
+      }));
+
+      // Same two topics as the previous sample, reassigned ids — and the
+      // preferred one is no longer first in the list.
+      renderScoped([audio("7", micFront), audio("9", micRear)]);
+
+      expect(headerLabel()).toContain("Mic Rear");
+    });
+
+    it("re-resolves when a new sample's inventory replaces the ids it bound at mount", () => {
+      updateSidebarPreferences(SCOPE, (current) => ({
+        ...current,
+        tiles: {
+          ...current.tiles,
+          "audio-tile-1": {
+            audioSourceKey: semanticSourceKey({
+              sourceName: micRear.sourceName,
+              type: "audio",
+            }),
+          },
+        },
+      }));
+      const { rerender } = renderScoped(
+        [audio("1", micFront), audio("2", micRear)],
+        "2",
+      );
+      expect(headerLabel()).toContain("Mic Rear");
+
+      const nextSample = [audio("4", micFront), audio("5", micRear)];
+      mocks.sources = nextSample;
+      rerender(
+        <SidebarPreferencesProvider scopeKey={SCOPE} sources={nextSample}>
+          <AudioTile initialSourceId="2" />
+        </SidebarPreferencesProvider>,
+      );
+
+      // Before the fix this fell through to `sources[0]` — "Mic Front".
+      expect(headerLabel()).toContain("Mic Rear");
+    });
+
+    it("falls back to the first source when the persisted topic is absent from this sample", () => {
+      updateSidebarPreferences(SCOPE, (current) => ({
+        ...current,
+        tiles: {
+          ...current.tiles,
+          "audio-tile-1": {
+            audioSourceKey: semanticSourceKey({
+              sourceName: "/mic_gone",
+              type: "audio",
+            }),
+          },
+        },
+      }));
+
+      renderScoped([audio("1", micFront), audio("2", micRear)]);
+
+      expect(headerLabel()).toContain("Mic Front");
+    });
   });
 });

--- a/app/packages/multimodal/src/views/episode/audio/AudioTile.test.tsx
+++ b/app/packages/multimodal/src/views/episode/audio/AudioTile.test.tsx
@@ -1,4 +1,5 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { act, cleanup, render, screen, within } from "@testing-library/react";
+import { createStore, Provider as JotaiProvider } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -12,6 +13,9 @@ const mocks = vi.hoisted(() => ({
     type: string;
   }>,
   waveformTracks: [] as Array<{ pyramid: unknown }>,
+  tileSettings: null as {
+    content: { props: { onSelectSource: (sourceId: string) => void } };
+  } | null,
   pcmResult: {
     waveformPeaks: null as unknown,
     hasAudio: false,
@@ -25,10 +29,18 @@ vi.mock("@fiftyone/tiling", () => ({
   useTileId: () => "audio-tile-1",
 }));
 
-// The tile publishes a source picker to the sidebar; registering it needs a
-// provider this unit test has no reason to mount.
+// The tile publishes a source picker to the sidebar; registering it for real
+// needs a provider this unit test has no reason to mount, so the stub keeps
+// the registration for tests that drive the picker's callback directly.
 vi.mock("../tiles/tile-settings-context", () => ({
-  useRegisterTileSettings: () => undefined,
+  useRegisterTileSettings: (
+    _tileId: string | undefined,
+    registration: {
+      content: { props: { onSelectSource: (sourceId: string) => void } };
+    },
+  ) => {
+    mocks.tileSettings = registration;
+  },
 }));
 
 vi.mock("@fiftyone/playback", () => ({
@@ -72,8 +84,12 @@ vi.mock("./WaveformSurface", () => ({
   ),
 }));
 
+import { persistedAudioTileBindingsAtom } from "../tiles/tile-source-bindings";
 import { semanticSourceKey } from "../settings/semantic-source";
-import { updateSidebarPreferences } from "../settings/sidebar-preferences";
+import {
+  readSidebarPreferences,
+  updateSidebarPreferences,
+} from "../settings/sidebar-preferences";
 import { SidebarPreferencesProvider } from "../settings/sidebar-preferences-context";
 import AudioTile from "./AudioTile";
 
@@ -82,6 +98,7 @@ describe("AudioTile", () => {
     cleanup();
     vi.clearAllMocks();
     mocks.sources = [];
+    mocks.tileSettings = null;
     mocks.pcmResult = { waveformPeaks: null, hasAudio: false, status: "idle" };
   });
 
@@ -243,6 +260,43 @@ describe("AudioTile", () => {
       );
 
       // Before the fix this fell through to `sources[0]` — "Mic Front".
+      expect(headerLabel()).toContain("Mic Rear");
+    });
+
+    it("persists a picked source, so the next sample's ids resolve back to it", () => {
+      renderScoped([audio("1", micFront), audio("2", micRear)]);
+      expect(headerLabel()).toContain("Mic Front");
+
+      // Stand-in for the user choosing the topic in the tile's settings.
+      act(() => {
+        mocks.tileSettings?.content.props.onSelectSource("2");
+      });
+      expect(headerLabel()).toContain("Mic Rear");
+      // Stored semantically, never as the runtime id — that id belongs to
+      // this sample only.
+      expect(
+        readSidebarPreferences(SCOPE).tiles["audio-tile-1"]?.audioSourceKey,
+      ).toBe(
+        semanticSourceKey({ sourceName: micRear.sourceName, type: "audio" }),
+      );
+
+      cleanup();
+      renderScoped([audio("7", micFront), audio("9", micRear)]);
+      expect(headerLabel()).toContain("Mic Rear");
+    });
+
+    it("follows the durable binding when there is no dataset scope to persist a key to", () => {
+      // Without a scope the modal-scoped atom is the pane's only memory of
+      // its topic; the tile still has to prefer it over `sources[0]`.
+      const store = createStore();
+      store.set(persistedAudioTileBindingsAtom, { "audio-tile-1": "2" });
+      mocks.sources = [audio("1", micFront), audio("2", micRear)];
+      render(
+        <JotaiProvider store={store}>
+          <AudioTile />
+        </JotaiProvider>,
+      );
+
       expect(headerLabel()).toContain("Mic Rear");
     });
 

--- a/app/packages/multimodal/src/views/episode/audio/AudioTile.tsx
+++ b/app/packages/multimodal/src/views/episode/audio/AudioTile.tsx
@@ -14,6 +14,7 @@ import {
   TextVariant,
   Variant,
 } from "@voxel51/voodo";
+import { useStore } from "jotai";
 import React, {
   useCallback,
   useEffect,
@@ -29,9 +30,12 @@ import { SCENE_SOURCE_TYPE } from "../../../ir";
 import { useSceneSourcesByType } from "../../../scene-inventory/react";
 import type { EpisodeTileProps } from "../tiles/tile-types";
 import { channelLabel, synthesizePeaks } from "../../../audio/peak-pyramid";
-import { usePanelVisibilityScope } from "../settings/sidebar-preferences-context";
-import { semanticSourceKey } from "../settings/semantic-source";
-import { updateSidebarPreferences } from "../settings/sidebar-preferences";
+import {
+  persistedAudioTileBindingsAtom,
+  resolveAvailableAudioStream,
+  usePersistAudioTileBinding,
+  usePreferredAudioTileStream,
+} from "../tiles/tile-source-bindings";
 import { useRegisterTileSettings } from "../tiles/tile-settings-context";
 import AudioTileSettings from "./AudioTileSettings";
 import styles from "./AudioTile.module.css";
@@ -55,38 +59,51 @@ const AudioTile: React.FC<EpisodeTileProps> = ({ initialSourceId }) => {
   // and offer no way to change it, so a recording with several audio topics
   // could only ever show the first one — and the `initialSourceId` the host
   // passes when a tile is opened for a specific source was ignored outright.
-  const [selectedSourceId, setSelectedSourceId] = useState<string | undefined>(
+  const [primarySourceId, setPrimarySourceId] = useState<string | undefined>(
     () => initialSourceId ?? sources[0]?.id,
   );
-  const preferenceScope = usePanelVisibilityScope();
+  const jotaiStore = useStore();
+  const preferredSourceId = usePreferredAudioTileStream();
   /** Wheel-zoom surface spanning the ruler and the waveform beneath it. */
   const zoomRef = useRef<HTMLDivElement>(null);
 
-  // Persist the choice so it survives a refresh. Stored as a semantic key,
-  // never the runtime source id: ids are positional and get reassigned
-  // between loads, so a persisted id would restore a different topic. This
-  // is the same mechanism image tiles use for their camera.
+  // Persist the choice so it survives a refresh and sample navigation. Stored
+  // as a semantic key, never the runtime source id: ids are positional and
+  // get reassigned between loads, so a persisted id would restore a different
+  // topic. Same mechanism image tiles use for their camera.
+  const persistAudioTileBinding = usePersistAudioTileBinding(
+    primarySourceId ?? "",
+  );
   const selectSource = useCallback(
     (nextSourceId: string) => {
-      setSelectedSourceId(nextSourceId);
-      const source = sources.find((candidate) => candidate.id === nextSourceId);
-      if (!preferenceScope || !source || !tileId) return;
-      const audioSourceKey = semanticSourceKey(source);
-      updateSidebarPreferences(preferenceScope, (current) => ({
-        ...current,
-        tiles: {
-          ...current.tiles,
-          [tileId]: { ...current.tiles[tileId], audioSourceKey },
-        },
-      }));
+      persistAudioTileBinding(nextSourceId);
+      setPrimarySourceId(nextSourceId);
     },
-    [preferenceScope, sources, tileId],
+    [persistAudioTileBinding],
   );
-  // A source can disappear between recordings; fall back rather than bind to
-  // an id the inventory no longer has.
-  const primarySourceId =
-    sources.find((source) => source.id === selectedSourceId)?.id ??
-    sources[0]?.id;
+
+  // This effect restores a returning durable preference or temporarily falls
+  // back when the current sample lacks it. The shell stays mounted across
+  // sample navigation and runtime ids are reassigned per recording, so the id
+  // bound at mount goes stale the moment a new inventory lands — the tile used
+  // to notice only that the id was missing and drop to `sources[0]`, snapping
+  // every audio pane onto the first topic even when the new sample carried the
+  // same ones. Automatic fallback never writes the preference, so a later
+  // sample can restore the user's chosen source.
+  useEffect(() => {
+    const preferredStream =
+      preferredSourceId ??
+      (tileId
+        ? jotaiStore.get(persistedAudioTileBindingsAtom)[tileId]
+        : undefined);
+    const nextSourceId = resolveAvailableAudioStream(
+      primarySourceId,
+      preferredStream,
+      sources,
+    );
+    if (nextSourceId !== primarySourceId) setPrimarySourceId(nextSourceId);
+  }, [jotaiStore, preferredSourceId, primarySourceId, sources, tileId]);
+
   const primarySource = sources.find((source) => source.id === primarySourceId);
   const setTileTitle = useSetTileTitle();
   const setHeaderExtra = useSetTileHeaderExtra();

--- a/app/packages/multimodal/src/views/episode/layout/use-modal-layout.test.tsx
+++ b/app/packages/multimodal/src/views/episode/layout/use-modal-layout.test.tsx
@@ -24,6 +24,10 @@ import {
   scene3dTilePlaybackSettingsAtom,
   type Scene3dTilePlaybackSettingsByTile,
 } from "../scene/tile/scene-3d-tile-state";
+import {
+  persistedAudioTileBindingsAtom,
+  persistedImageTileBindingsAtom,
+} from "../tiles/tile-source-bindings";
 import { cameraScopeKey } from "../scope/camera-scope";
 import { updateSidebarPreferences } from "../settings/sidebar-preferences";
 import { semanticSourceKey } from "../settings/semantic-source";
@@ -1089,6 +1093,125 @@ describe("ModalLayoutPersistence", () => {
 
     unmount();
     expect(readModalLayout("dataset-a")?.expandedTileId).toBe("camera-default");
+  });
+
+  function TileRemovalDriver({ tileId }: { tileId: string | null }) {
+    const { removeTile } = useTiling();
+    // This effect drives pane removal from test props — stand-in for the
+    // user closing a tile.
+    useEffect(() => {
+      if (tileId) removeTile(tileId);
+    }, [removeTile, tileId]);
+    return null;
+  }
+
+  function BindingSeeder({
+    audio,
+    image,
+  }: {
+    readonly audio: Readonly<Record<string, string>>;
+    readonly image: Readonly<Record<string, string>>;
+  }) {
+    const store = useStore();
+    // This effect stands in for mounted panes having published their
+    // durable bindings; it runs before the pruning effect below it. Each
+    // map only ever holds its own kind's tile ids — a pruning pass sees
+    // only the live tiles of its kind, so a foreign id there reads as
+    // stale.
+    useEffect(() => {
+      store.set(persistedImageTileBindingsAtom, image);
+      store.set(persistedAudioTileBindingsAtom, audio);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return null;
+  }
+
+  function BindingsProbe({
+    onValue,
+  }: {
+    readonly onValue: (value: {
+      readonly audio: Readonly<Record<string, string>>;
+      readonly image: Readonly<Record<string, string>>;
+    }) => void;
+  }) {
+    const audio = useAtomValue(persistedAudioTileBindingsAtom);
+    const image = useAtomValue(persistedImageTileBindingsAtom);
+    // This effect exposes atom updates to the test assertion.
+    useEffect(() => {
+      onValue({ audio, image });
+    }, [audio, image, onValue]);
+    return null;
+  }
+
+  // Audio panes persist a durable binding the same way image panes do, so
+  // both maps have to be pruned on pane removal — a leftover entry would
+  // resurrect a closed pane's topic on the next pane to reuse its id.
+  describe("pruning durable tile bindings", () => {
+    const FOUR_TILES = {
+      "audio-1": { title: "Audio", render: () => null },
+      "audio-2": { title: "Audio compare", render: () => null },
+      "image-1": { title: "Camera", render: () => null },
+      "image-2": { title: "Camera compare", render: () => null },
+    };
+    const SEEDED_AUDIO = { "audio-1": "mic_front", "audio-2": "mic_rear" };
+    const SEEDED_IMAGE = { "image-1": "cam_front", "image-2": "cam_rear" };
+
+    function renderWithRemoval(
+      removedTileId: string | null,
+      seeds: {
+        readonly audio?: Readonly<Record<string, string>>;
+        readonly image?: Readonly<Record<string, string>>;
+      } = {},
+    ) {
+      const values: Array<{
+        readonly audio: Readonly<Record<string, string>>;
+        readonly image: Readonly<Record<string, string>>;
+      }> = [];
+      const view = render(
+        <TilingProvider initialTiles={FOUR_TILES}>
+          <BindingSeeder
+            audio={seeds.audio ?? SEEDED_AUDIO}
+            image={seeds.image ?? SEEDED_IMAGE}
+          />
+          <ModalLayoutPersistence datasetId="dataset-a" />
+          <TileRemovalDriver tileId={removedTileId} />
+          <BindingsProbe onValue={(value) => values.push(value)} />
+        </TilingProvider>,
+      );
+      return { latest: () => values.at(-1), view };
+    }
+
+    it("keeps every binding while its pane is still in the layout", () => {
+      const { latest } = renderWithRemoval(null);
+      expect(latest()?.image).toEqual(SEEDED_IMAGE);
+      expect(latest()?.audio).toEqual(SEEDED_AUDIO);
+    });
+
+    it("drops an audio binding when its pane leaves the layout", () => {
+      const { latest } = renderWithRemoval("audio-2");
+      expect(latest()?.audio).toEqual({
+        "audio-1": "mic_front",
+      });
+    });
+
+    it("drops an image binding when its pane leaves the layout", () => {
+      const { latest } = renderWithRemoval("image-2");
+      expect(latest()?.image).toEqual({
+        "image-1": "cam_front",
+      });
+    });
+
+    it("prunes each tile kind against its own live panes, not every pane", () => {
+      // Both maps are keyed by tile id, so each pass has to be told which
+      // kind it reconciles. An image id in the audio map is stale by
+      // construction — an audio pane never binds one — and a pass that
+      // measured against every live tile would keep it.
+      const { latest } = renderWithRemoval(null, {
+        audio: { ...SEEDED_AUDIO, "image-1": "cam_front" },
+      });
+      expect(latest()?.audio).toEqual(SEEDED_AUDIO);
+      expect(latest()?.image).toEqual(SEEDED_IMAGE);
+    });
   });
 
   it("does not persist a layout the user never edited", () => {

--- a/app/packages/multimodal/src/views/episode/layout/use-modal-layout.tsx
+++ b/app/packages/multimodal/src/views/episode/layout/use-modal-layout.tsx
@@ -44,7 +44,10 @@ import {
   type PlotSeriesConfig,
 } from "../plots/plot-tile-state";
 import { rawTileStreamAtom } from "../tiles/raw-message-binding";
-import { persistedImageTileBindingsAtom } from "../tiles/tile-source-bindings";
+import {
+  persistedAudioTileBindingsAtom,
+  persistedImageTileBindingsAtom,
+} from "../tiles/tile-source-bindings";
 import { cameraScopeKey } from "../scope/camera-scope";
 import { readSidebarPreferences } from "../settings/sidebar-preferences";
 import { createSemanticSourceIndex } from "../settings/semantic-source";
@@ -646,7 +649,18 @@ export function ModalLayoutPersistence({
     tilesRef,
   });
 
-  usePrunePersistedImageBindings(store, tiles);
+  usePrunePersistedTileBindings(
+    store,
+    tiles,
+    TILE_TYPE.IMAGE,
+    persistedImageTileBindingsAtom,
+  );
+  usePrunePersistedTileBindings(
+    store,
+    tiles,
+    TILE_TYPE.AUDIO,
+    persistedAudioTileBindingsAtom,
+  );
 
   const plotSeriesPatch = useCallback(
     (value: Readonly<Record<string, readonly PlotSeriesConfig[]>>) => ({
@@ -967,29 +981,31 @@ type PersistedTileAtomField =
   | "scene3dSettings";
 
 /** Remove durable bindings only when their pane leaves the live layout. */
-function usePrunePersistedImageBindings(
+function usePrunePersistedTileBindings(
   store: ReturnType<typeof useStore>,
   tiles: Readonly<Record<string, TilingTile>>,
+  tileType: TileType,
+  bindingsAtom: PrimitiveAtom<Readonly<Record<string, string>>>,
 ): void {
-  const imageTileIdsKey = Object.keys(tiles)
-    .filter((tileId) => tileTypeFromId(tileId) === TILE_TYPE.IMAGE)
+  const liveTileIdsKey = Object.keys(tiles)
+    .filter((tileId) => tileTypeFromId(tileId) === tileType)
     .join("\u0000");
 
   // This effect reconciles intentional pane removal with durable bindings.
   useEffect(() => {
-    const imageTileIds = new Set(
-      imageTileIdsKey ? imageTileIdsKey.split("\u0000") : [],
+    const liveTileIds = new Set(
+      liveTileIdsKey ? liveTileIdsKey.split("\u0000") : [],
     );
-    store.set(persistedImageTileBindingsAtom, (previous) => {
+    store.set(bindingsAtom, (previous) => {
       const staleIds = Object.keys(previous).filter(
-        (tileId) => !imageTileIds.has(tileId),
+        (tileId) => !liveTileIds.has(tileId),
       );
       if (staleIds.length === 0) return previous;
       const next = { ...previous };
       for (const tileId of staleIds) delete next[tileId];
       return next;
     });
-  }, [imageTileIdsKey, store]);
+  }, [bindingsAtom, liveTileIdsKey, store]);
 }
 
 /**

--- a/app/packages/multimodal/src/views/episode/tiles/tile-source-bindings.test.tsx
+++ b/app/packages/multimodal/src/views/episode/tiles/tile-source-bindings.test.tsx
@@ -10,16 +10,23 @@ import { createStore, Provider as JotaiProvider, useAtomValue } from "jotai";
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { SceneSource } from "../../../scene-inventory";
-import { readSidebarPreferences } from "../settings/sidebar-preferences";
+import {
+  readSidebarPreferences,
+  updateSidebarPreferences,
+} from "../settings/sidebar-preferences";
 import { semanticSourceKey } from "../settings/semantic-source";
 import {
   chooseNextImageStream,
   hoveredImageStreamAtom,
+  persistedAudioTileBindingsAtom,
   persistedImageTileBindingsAtom,
+  resolveAvailableAudioStream,
   resolveAvailableImageStream,
   useImageTileBindings,
   useImageTileHoverProps,
+  usePersistAudioTileBinding,
   usePersistImageTileBinding,
+  usePreferredAudioTileStream,
   usePreferredImageTileStream,
   usePublishImageTileBinding,
 } from "./tile-source-bindings";
@@ -27,6 +34,10 @@ import { PanelVisibilityProvider } from "./panel-visibility";
 
 function imageSource(id: string): SceneSource {
   return { id, label: id.toUpperCase(), sourceName: id, type: "image" };
+}
+
+function audioSource(id: string, sourceName: string): SceneSource {
+  return { id, label: sourceName, sourceName, type: "audio" };
 }
 
 describe("chooseNextImageStream", () => {
@@ -343,5 +354,242 @@ describe("useImageTileHoverProps", () => {
     act(() => result.current.onPointerEnter());
     unmount();
     expect(store.get(hoveredImageStreamAtom)).toBeNull();
+  });
+});
+
+describe("resolveAvailableAudioStream", () => {
+  const front = audioSource("1", "/mic_front");
+  const rear = audioSource("2", "/mic_rear");
+
+  it("prefers the durable preference over the currently displayed source", () => {
+    expect(resolveAvailableAudioStream("1", "2", [front, rear])).toBe("2");
+  });
+
+  it("keeps an available current source while the preference is unresolvable", () => {
+    // `null` is the preference existing but pointing at a topic this sample
+    // lacks; `undefined` is no preference at all. Neither may disturb a
+    // source the pane is already showing.
+    expect(resolveAvailableAudioStream("2", null, [front, rear])).toBe("2");
+    expect(resolveAvailableAudioStream("2", undefined, [front, rear])).toBe(
+      "2",
+    );
+  });
+
+  it("re-resolves onto the preference after the sample reassigns ids", () => {
+    // Same two topics as the previous sample under new positional ids: the
+    // id the pane bound at mount is gone, and the preference resolved
+    // against the new inventory has to win over `sources[0]`.
+    const shifted = [
+      audioSource("7", "/mic_front"),
+      audioSource("9", "/mic_rear"),
+    ];
+    expect(resolveAvailableAudioStream("2", "9", shifted)).toBe("9");
+  });
+
+  it("falls back to the first source when neither preference nor current is present", () => {
+    expect(resolveAvailableAudioStream("9", "8", [front, rear])).toBe("1");
+    expect(
+      resolveAvailableAudioStream(undefined, undefined, [front, rear]),
+    ).toBe("1");
+  });
+
+  it("resolves to nothing when the sample carries no audio", () => {
+    expect(resolveAvailableAudioStream("1", "2", [])).toBeUndefined();
+  });
+});
+
+const PersistedAudioBindingsProbe: React.FC = () => (
+  <span data-testid="persisted-audio-bindings">
+    {JSON.stringify(useAtomValue(persistedAudioTileBindingsAtom))}
+  </span>
+);
+
+// `undefined` (no preference) and `null` (a preference this sample cannot
+// resolve) drive different fallback behavior, so the probe keeps them apart
+// rather than collapsing both to an empty string.
+const PreferredAudioBindingProbe: React.FC = () => {
+  const preferred = usePreferredAudioTileStream();
+  return (
+    <span data-testid="preferred-audio-binding">
+      {preferred === undefined ? "undefined" : (preferred ?? "null")}
+    </span>
+  );
+};
+
+const AudioPreferencePublisher: React.FC<{
+  readonly selectedSourceId?: string;
+  readonly sourceId: string;
+}> = ({ selectedSourceId, sourceId }) => {
+  const persistBinding = usePersistAudioTileBinding(sourceId);
+  // This effect stands in for the user picking a topic in tile settings.
+  React.useEffect(() => {
+    if (selectedSourceId) persistBinding(selectedSourceId);
+  }, [persistBinding, selectedSourceId]);
+  return null;
+};
+
+describe("usePreferredAudioTileStream", () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  function renderProbe(
+    sources: readonly SceneSource[],
+    scopeKey?: string,
+  ): void {
+    render(
+      <PanelVisibilityProvider scopeKey={scopeKey} sources={sources}>
+        <TilingProvider>
+          <TileIdScope tileId="audio-1">
+            <PreferredAudioBindingProbe />
+          </TileIdScope>
+        </TilingProvider>
+      </PanelVisibilityProvider>,
+    );
+  }
+
+  function persistKey(sourceName: string): void {
+    updateSidebarPreferences("dataset-a", (current) => ({
+      ...current,
+      tiles: {
+        ...current.tiles,
+        "audio-1": {
+          ...current.tiles["audio-1"],
+          audioSourceKey: semanticSourceKey({ sourceName, type: "audio" }),
+        },
+      },
+    }));
+  }
+
+  it("has no preference without a dataset scope to read one from", () => {
+    persistKey("/mic_rear");
+    renderProbe([audioSource("2", "/mic_rear")]);
+    expect(screen.getByTestId("preferred-audio-binding").textContent).toBe(
+      "undefined",
+    );
+  });
+
+  it("has no preference when the scope never stored one for this tile", () => {
+    renderProbe([audioSource("2", "/mic_rear")], "dataset-a");
+    expect(screen.getByTestId("preferred-audio-binding").textContent).toBe(
+      "undefined",
+    );
+  });
+
+  it("resolves the stored semantic key against the sample's runtime ids", () => {
+    persistKey("/mic_rear");
+    renderProbe(
+      [audioSource("7", "/mic_front"), audioSource("9", "/mic_rear")],
+      "dataset-a",
+    );
+    expect(screen.getByTestId("preferred-audio-binding").textContent).toBe("9");
+  });
+
+  it("reports an unresolvable preference as null rather than absent", () => {
+    persistKey("/mic_gone");
+    renderProbe([audioSource("1", "/mic_front")], "dataset-a");
+    expect(screen.getByTestId("preferred-audio-binding").textContent).toBe(
+      "null",
+    );
+  });
+});
+
+describe("usePersistAudioTileBinding", () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  const front = audioSource("1", "/mic_front");
+  const rear = audioSource("2", "/mic_rear");
+
+  function renderPublisher(
+    sources: readonly SceneSource[],
+    props: { readonly selectedSourceId?: string; readonly sourceId: string },
+    scopeKey?: string,
+  ) {
+    const tree = (
+      nextSources: readonly SceneSource[],
+      nextProps: {
+        readonly selectedSourceId?: string;
+        readonly sourceId: string;
+      },
+    ) => (
+      <PanelVisibilityProvider scopeKey={scopeKey} sources={nextSources}>
+        <TilingProvider>
+          <TileIdScope tileId="audio-1">
+            <AudioPreferencePublisher {...nextProps} />
+            <PreferredAudioBindingProbe />
+          </TileIdScope>
+          <PersistedAudioBindingsProbe />
+        </TilingProvider>
+      </PanelVisibilityProvider>
+    );
+    const view = render(tree(sources, props));
+    return {
+      ...view,
+      rerenderWith: (
+        nextSources: readonly SceneSource[],
+        nextProps: {
+          readonly selectedSourceId?: string;
+          readonly sourceId: string;
+        },
+      ) => view.rerender(tree(nextSources, nextProps)),
+    };
+  }
+
+  const persisted = () =>
+    screen.getByTestId("persisted-audio-bindings").textContent;
+  const storedKey = () =>
+    readSidebarPreferences("dataset-a").tiles["audio-1"]?.audioSourceKey;
+
+  it("seeds a new pane's durable preference from the source it opened on", () => {
+    renderPublisher([front, rear], { sourceId: "2" }, "dataset-a");
+    expect(persisted()).toBe('{"audio-1":"2"}');
+    expect(storedKey()).toBe(semanticSourceKey(rear));
+  });
+
+  it("records an intentional selection in both the scope and the atom", () => {
+    const view = renderPublisher([front, rear], { sourceId: "1" }, "dataset-a");
+    expect(storedKey()).toBe(semanticSourceKey(front));
+
+    view.rerenderWith([front, rear], { selectedSourceId: "2", sourceId: "1" });
+    expect(persisted()).toBe('{"audio-1":"2"}');
+    expect(storedKey()).toBe(semanticSourceKey(rear));
+  });
+
+  it("leaves the stored preference alone while a sample lacks its topic", () => {
+    const view = renderPublisher([front, rear], { sourceId: "2" }, "dataset-a");
+    expect(storedKey()).toBe(semanticSourceKey(rear));
+
+    // The next sample dropped `/mic_rear`, so the tile is displaying its
+    // automatic fallback. That fallback must not be mistaken for a choice.
+    view.rerenderWith([front], { sourceId: "1" });
+    expect(screen.getByTestId("preferred-audio-binding").textContent).toBe(
+      "null",
+    );
+    expect(storedKey()).toBe(semanticSourceKey(rear));
+
+    // A later sample carries the topic again, under a new id.
+    const returned = audioSource("9", "/mic_rear");
+    view.rerenderWith([front, returned], { sourceId: "1" });
+    expect(screen.getByTestId("preferred-audio-binding").textContent).toBe("9");
+    expect(persisted()).toBe('{"audio-1":"9"}');
+  });
+
+  it("carries the pane's choice in the atom when there is no scope to persist to", () => {
+    const view = renderPublisher([front, rear], { sourceId: "2" });
+    expect(persisted()).toBe('{"audio-1":"2"}');
+    expect(storedKey()).toBeUndefined();
+
+    // Without a scope the atom is the only memory the pane has, so a
+    // fallback display must not overwrite it...
+    view.rerenderWith([front], { sourceId: "1" });
+    expect(persisted()).toBe('{"audio-1":"2"}');
+
+    // ...while an explicit selection still must.
+    view.rerenderWith([front], { selectedSourceId: "1", sourceId: "1" });
+    expect(persisted()).toBe('{"audio-1":"1"}');
   });
 });

--- a/app/packages/multimodal/src/views/episode/tiles/tile-source-bindings.ts
+++ b/app/packages/multimodal/src/views/episode/tiles/tile-source-bindings.ts
@@ -31,6 +31,13 @@ export const imageTileBindingsAtom = atom<ImageTileBindings>({});
  */
 export const persistedImageTileBindingsAtom = atom<ImageTileBindings>({});
 
+/**
+ * Durable preferred source per audio tile — the audio counterpart to
+ * {@link persistedImageTileBindingsAtom}, and the fallback that carries a
+ * pane's choice when there is no dataset scope to persist a semantic key to.
+ */
+export const persistedAudioTileBindingsAtom = atom<ImageTileBindings>({});
+
 /** Subscribe to the current tile→source bindings map. */
 export function useImageTileBindings(): Readonly<Record<string, string>> {
   return useAtomValue(imageTileBindingsAtom);
@@ -47,6 +54,22 @@ export function usePreferredImageTileStream(): string | null | undefined {
   if (!tileId || !scopeKey) return undefined;
   const preferredKey =
     readSidebarPreferences(scopeKey).tiles[tileId]?.imageSourceKey;
+  return preferredKey
+    ? (identity.runtimeIdsForKey(preferredKey)[0] ?? null)
+    : undefined;
+}
+
+/**
+ * Resolves this audio tile's durable semantic preference to a runtime id.
+ * `null` means the preference exists but its source is currently unavailable.
+ */
+export function usePreferredAudioTileStream(): string | null | undefined {
+  const tileId = useTileId();
+  const scopeKey = usePanelVisibilityScope();
+  const identity = useSidebarSourceIdentity();
+  if (!tileId || !scopeKey) return undefined;
+  const preferredKey =
+    readSidebarPreferences(scopeKey).tiles[tileId]?.audioSourceKey;
   return preferredKey
     ? (identity.runtimeIdsForKey(preferredKey)[0] ?? null)
     : undefined;
@@ -131,6 +154,65 @@ export function usePersistImageTileBinding(
         }));
       }
       store.set(persistedImageTileBindingsAtom, (previous) =>
+        previous[tileId] === nextSourceId
+          ? previous
+          : { ...previous, [tileId]: nextSourceId },
+      );
+    },
+    [identity, scopeKey, store, tileId],
+  );
+}
+
+/**
+ * Audio counterpart to {@link usePersistImageTileBinding}: seeds a new audio
+ * pane's durable preference and returns the setter intentional selection
+ * calls. Automatic fallbacks (a sample that lacks the preferred topic) never
+ * reach this, so a later sample can still restore the user's chosen source.
+ */
+export function usePersistAudioTileBinding(
+  sourceId: string,
+): (sourceId: string) => void {
+  const tileId = useTileId();
+  const store = useStore();
+  const scopeKey = usePanelVisibilityScope();
+  const identity = useSidebarSourceIdentity();
+  const preferredRuntimeId = usePreferredAudioTileStream();
+
+  // This effect records pane creation/duplication in durable modal state.
+  useEffect(() => {
+    if (!tileId || !sourceId) return;
+    const runtimeId = preferredRuntimeId ?? sourceId;
+    store.set(persistedAudioTileBindingsAtom, (previous) =>
+      (!scopeKey && previous[tileId]) || previous[tileId] === runtimeId
+        ? previous
+        : { ...previous, [tileId]: runtimeId },
+    );
+    if (!scopeKey || preferredRuntimeId !== undefined) return;
+    const sourceKey = identity.keyForRuntimeId(sourceId);
+    if (!sourceKey) return;
+    updateSidebarPreferences(scopeKey, (current) => ({
+      ...current,
+      tiles: {
+        ...current.tiles,
+        [tileId]: { ...current.tiles[tileId], audioSourceKey: sourceKey },
+      },
+    }));
+  }, [identity, preferredRuntimeId, scopeKey, sourceId, store, tileId]);
+
+  return useCallback(
+    (nextSourceId: string) => {
+      if (!tileId || !nextSourceId) return;
+      const sourceKey = identity.keyForRuntimeId(nextSourceId);
+      if (scopeKey && sourceKey) {
+        updateSidebarPreferences(scopeKey, (current) => ({
+          ...current,
+          tiles: {
+            ...current.tiles,
+            [tileId]: { ...current.tiles[tileId], audioSourceKey: sourceKey },
+          },
+        }));
+      }
+      store.set(persistedAudioTileBindingsAtom, (previous) =>
         previous[tileId] === nextSourceId
           ? previous
           : { ...previous, [tileId]: nextSourceId },
@@ -235,6 +317,32 @@ export function chooseNextImageStream(
     rankedImages[0]?.id ??
     ""
   );
+}
+
+/**
+ * Audio counterpart to {@link resolveAvailableImageStream}. The playback
+ * shell stays mounted across sample navigation and runtime source ids are
+ * positional, so the id a pane bound at mount is meaningless once the next
+ * sample's inventory lands — without this the tile only noticed that its id
+ * was missing and dropped to the first source, so every audio pane snapped
+ * onto the same topic even when the new sample carried the same ones.
+ *
+ * Unlike images there is no collision-avoiding ranked pass: audio panes have
+ * no mounted-bindings registry, and two panes on one topic is not a bug.
+ */
+export function resolveAvailableAudioStream(
+  currentSourceId: string | undefined,
+  preferredSourceId: string | null | undefined,
+  availableAudio: readonly SceneSource[],
+): string | undefined {
+  const available = new Set(availableAudio.map((source) => source.id));
+  if (preferredSourceId && available.has(preferredSourceId)) {
+    return preferredSourceId;
+  }
+  if (currentSourceId && available.has(currentSourceId)) {
+    return currentSourceId;
+  }
+  return availableAudio[0]?.id;
 }
 
 /**


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

An audio tile resolved its source **once, at mount**, and never again — so navigating between samples collapsed every audio pane onto the first topic in the source list.

`AudioTile`'s `useState` initializer took `initialSourceId ?? sources[0]?.id`, and the only other resolution was a guard that dropped to `sources[0]?.id` when the bound id wasn't in the current inventory. Runtime `SceneSource` ids are positional and get reassigned per recording, and `SourcePlayback` deliberately keeps `PlaybackShell` mounted across source changes, so the id a pane bound on the first sample is meaningless by the second — that guard fired on *every* navigation, even when the new sample carried exactly the same topics.

The persistence itself was already in place and working: the tile stored a semantic key (`audioSourceKey`) rather than a runtime id, and `useModalLayout` resolved that key back to a current id via `resolveSemanticAudioBindings`. But that resolution only reaches a tile through `initialSourceId` at mount, and `TilingProvider` seeds its tile map with `useState` — so a recomputed binding never reaches an already-mounted pane. The missing piece was runtime re-resolution, which image tiles have and audio did not.

This gives audio the same binding trio the camera/image tiles use, in `tiles/tile-source-bindings.ts`:

- `persistedAudioTileBindingsAtom` — durable in-memory preference, so a pane keeps its choice even with no dataset scope to persist a semantic key to.
- `usePreferredAudioTileStream()` — maps the persisted semantic key to a runtime id in the current inventory; `null` distinguishes "preference exists but this sample lacks the topic" from "no preference".
- `usePersistAudioTileBinding(sourceId)` — seeds pane creation and returns the setter intentional selection calls.
- `resolveAvailableAudioStream(current, preferred, sources)` — preference wins, an available current selection stays put, and only an unavailable one falls back to the first source.

`AudioTile` then runs the reconciler in an effect on every inventory change, mirroring `ImageTile`. Automatic fallback never writes the preference, so a sample that genuinely lacks the chosen topic borrows another without destroying the choice for the next sample that has it.

Unlike images there's no collision-avoiding ranked fallback pass: audio panes have no mounted-bindings registry, and two panes on one topic isn't a bug.

Finally, `usePrunePersistedImageBindings` is generalized to `usePrunePersistedTileBindings(store, tiles, tileType, atom)` and called for both kinds, so audio bindings are collected when their pane leaves the layout rather than leaking across the modal's lifetime.

https://github.com/user-attachments/assets/7ef22e52-37d0-4f60-82f8-e31e112f11fe


## 🧪 How is this patch tested? If it is not, please explain why.

Three new unit tests in `AudioTile.test.tsx`, under an `across sample navigation` block that mounts the tile inside a real `SidebarPreferencesProvider` and seeds a persisted `audioSourceKey`:

- follows its persisted topic into the next sample when the runtime ids have moved and the preferred topic is no longer first in the list;
- re-resolves on an in-place inventory swap (the mounted-shell case), rather than dropping to `sources[0]`;
- still falls back to the first source when the persisted topic is genuinely absent from this sample.

The two navigation tests were verified to **fail against the pre-fix logic** (both reported `Mic Front`, expected `Mic Rear`) before the fix was restored, so they're pinning the actual regression and not passing incidentally.

Full package suite green: 182 test files / 1728 tests under `packages/multimodal/src/views/episode`, plus `yarn check` in `packages/multimodal` (lint, types, deps, architecture, bounded-reads) all clean.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Audio tiles now stay on the topic you selected as you navigate between samples. Previously, moving to another sample reset every audio tile to the first audio source in the recording.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio tile source selections now persist across sample navigation.
  * Preferred audio sources are restored automatically, even when available source IDs change.
  * Audio selections made through the source picker are retained for future samples.

* **Bug Fixes**
  * Audio tiles now re-resolve sources when a sample’s audio inventory changes.
  * Tiles fall back to the current or first available source without losing saved preferences.
  * Stale saved bindings are cleared when image or audio tiles are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4031
<!-- enterprise-sync-pr:end -->