### PR TITLE
Annotate: number native-decode frames from the edit list's presentation start

### DIFF
--- a/app/packages/video-annotation/src/streams/editList.test.ts
+++ b/app/packages/video-annotation/src/streams/editList.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { presentationStart, presentedInOrder } from "./editList";
+
+describe("presentationStart", () => {
+  it("is 0 without an edit list", () => {
+    expect(presentationStart(undefined)).toBe(0);
+    expect(presentationStart([])).toBe(0);
+  });
+
+  it("is the media_time of the first edit", () => {
+    expect(
+      presentationStart([{ segment_duration: 9120, media_time: 96000 }]),
+    ).toBe(96000);
+  });
+
+  it("skips a leading empty edit", () => {
+    expect(
+      presentationStart([
+        { segment_duration: 500, media_time: -1 },
+        { segment_duration: 9120, media_time: 96000 },
+      ]),
+    ).toBe(96000);
+  });
+
+  it("is 0 when every edit is empty", () => {
+    expect(presentationStart([{ segment_duration: 500, media_time: -1 }])).toBe(
+      0,
+    );
+  });
+});
+
+describe("presentedInOrder", () => {
+  // 5 fps in a 1.2 MHz track timescale: one frame every 240000 ticks.
+  const FRAME = 240000;
+  const samples = [0, 1, 2, 3].map((i) => ({ cts: i * FRAME, id: i }));
+
+  it("numbers every sample when there is no edit list", () => {
+    expect(presentedInOrder(samples, 0).map((s) => s.id)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("drops samples before the presentation start as pre-roll", () => {
+    // An edit list starting 0.08s in: picture 1 (cts 0) precedes it and is
+    // pre-roll; frame 1 is picture 2 — what ffmpeg and OpenCV emit first.
+    expect(presentedInOrder(samples, 96000).map((s) => s.id)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("keeps a sample that starts exactly at the presentation start", () => {
+    expect(presentedInOrder(samples, FRAME).map((s) => s.id)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("orders by composition time, not decode order", () => {
+    // B-frame reordering: decode order I P B B, presentation order I B B P.
+    const reordered = [
+      { cts: 0, id: "I" },
+      { cts: 3 * FRAME, id: "P" },
+      { cts: 1 * FRAME, id: "B1" },
+      { cts: 2 * FRAME, id: "B2" },
+    ];
+    expect(presentedInOrder(reordered, 0).map((s) => s.id)).toEqual([
+      "I",
+      "B1",
+      "B2",
+      "P",
+    ]);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [{ cts: FRAME }, { cts: 0 }];
+    presentedInOrder(input, 0);
+    expect(input.map((s) => s.cts)).toEqual([FRAME, 0]);
+  });
+});

--- a/app/packages/video-annotation/src/streams/editList.test.ts
+++ b/app/packages/video-annotation/src/streams/editList.test.ts
@@ -6,9 +6,9 @@ import { describe, expect, it } from "vitest";
 import { presentationStart, presentedInOrder } from "./editList";
 
 describe("presentationStart", () => {
-  it("is 0 without an edit list", () => {
-    expect(presentationStart(undefined)).toBe(0);
-    expect(presentationStart([])).toBe(0);
+  it("is undefined without an edit list", () => {
+    expect(presentationStart(undefined)).toBeUndefined();
+    expect(presentationStart([])).toBeUndefined();
   });
 
   it("is the media_time of the first edit", () => {
@@ -26,10 +26,10 @@ describe("presentationStart", () => {
     ).toBe(96000);
   });
 
-  it("is 0 when every edit is empty", () => {
-    expect(presentationStart([{ segment_duration: 500, media_time: -1 }])).toBe(
-      0,
-    );
+  it("is undefined when every edit is empty", () => {
+    expect(
+      presentationStart([{ segment_duration: 500, media_time: -1 }]),
+    ).toBeUndefined();
   });
 });
 
@@ -39,7 +39,25 @@ describe("presentedInOrder", () => {
   const samples = [0, 1, 2, 3].map((i) => ({ cts: i * FRAME, id: i }));
 
   it("numbers every sample when there is no edit list", () => {
-    expect(presentedInOrder(samples, 0).map((s) => s.id)).toEqual([0, 1, 2, 3]);
+    expect(presentedInOrder(samples, undefined).map((s) => s.id)).toEqual([
+      0, 1, 2, 3,
+    ]);
+  });
+
+  it("keeps negative-cts samples when there is no edit list", () => {
+    // Signed composition offsets without an edit list: no boundary applies.
+    const signed = [
+      { cts: 0, id: "I" },
+      { cts: 2 * FRAME, id: "P" },
+      { cts: -FRAME, id: "B" },
+    ];
+    expect(presentedInOrder(signed, undefined).map((s) => s.id)).toEqual([
+      "B",
+      "I",
+      "P",
+    ]);
+    // An explicit boundary at 0 still drops them.
+    expect(presentedInOrder(signed, 0).map((s) => s.id)).toEqual(["I", "P"]);
   });
 
   it("drops samples before the presentation start as pre-roll", () => {

--- a/app/packages/video-annotation/src/streams/editList.test.ts
+++ b/app/packages/video-annotation/src/streams/editList.test.ts
@@ -43,8 +43,7 @@ describe("presentedInOrder", () => {
   });
 
   it("drops samples before the presentation start as pre-roll", () => {
-    // An edit list starting 0.08s in: picture 1 (cts 0) precedes it and is
-    // pre-roll; frame 1 is picture 2 — what ffmpeg and OpenCV emit first.
+    // Edit list starts 0.08 s in: picture 1 (cts 0) is pre-roll, frame 1 is picture 2.
     expect(presentedInOrder(samples, 96000).map((s) => s.id)).toEqual([
       1, 2, 3,
     ]);

--- a/app/packages/video-annotation/src/streams/editList.ts
+++ b/app/packages/video-annotation/src/streams/editList.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * Edit-list (`elst`) handling for the native decode path.
+ *
+ * An mp4 edit list tells players where in the stored media presentation
+ * begins. Encoders commonly write one to absorb start-up latency, so the first
+ * stored picture(s) sit before the presentation start. ffmpeg (and therefore
+ * OpenCV, `to_frames`, and any downstream pipeline that decodes with them)
+ * treats such samples as pre-roll: they are decoded for reference but never
+ * emitted, and frame 1 is the first sample at or after the edit start. Frame
+ * numbers written by Annotate must follow the same rule or they land one
+ * frame off in every consumer's decode.
+ *
+ * Pure functions — no mp4box, no workers — so the rule is unit-testable.
+ */
+
+/** One `elst` entry as mp4box exposes it on `Track.edits`. */
+export interface EditListEntry {
+  /** Duration of the edit in the presentation, in movie timescale units. */
+  segment_duration: number;
+  /**
+   * Media time where this edit starts, in track timescale units. `-1` marks an
+   * empty edit (a gap in the presentation with no media).
+   */
+  media_time: number;
+}
+
+/**
+ * Media time (track timescale units) at which presentation begins: the
+ * `media_time` of the first non-empty edit, or `0` when there is no edit list.
+ */
+export function presentationStart(
+  edits: readonly EditListEntry[] | undefined,
+): number {
+  if (!edits) {
+    return 0;
+  }
+
+  for (const edit of edits) {
+    if (edit.media_time >= 0) {
+      return edit.media_time;
+    }
+  }
+
+  return 0;
+}
+
+/** The composition timestamp of a sample, in track timescale units. */
+export interface TimedSample {
+  cts: number;
+}
+
+/**
+ * The samples that receive frame numbers, in presentation order: every sample
+ * whose composition time is at or after `start`, sorted ascending by `cts`.
+ * Samples before `start` are pre-roll — decoded when a GOP needs them, never
+ * numbered. Frame `n` is `presentedInOrder(...)[n - 1]`.
+ */
+export function presentedInOrder<T extends TimedSample>(
+  samples: readonly T[],
+  start: number,
+): T[] {
+  return samples.filter((s) => s.cts >= start).sort((a, b) => a.cts - b.cts);
+}

--- a/app/packages/video-annotation/src/streams/editList.ts
+++ b/app/packages/video-annotation/src/streams/editList.ts
@@ -17,21 +17,15 @@ export interface EditListEntry {
   media_time: number;
 }
 
-/** Media time where presentation begins: the first non-empty edit's `media_time`, else 0. */
+/**
+ * Media time where presentation begins: the first non-empty edit's
+ * `media_time`. `undefined` without an edit list — no boundary, so every
+ * sample is presented, including ones with negative `cts`.
+ */
 export function presentationStart(
   edits: readonly EditListEntry[] | undefined,
-): number {
-  if (!edits) {
-    return 0;
-  }
-
-  for (const edit of edits) {
-    if (edit.media_time >= 0) {
-      return edit.media_time;
-    }
-  }
-
-  return 0;
+): number | undefined {
+  return edits?.find((edit) => edit.media_time >= 0)?.media_time;
 }
 
 /** Sample composition time, in track timescale units. */
@@ -39,10 +33,12 @@ export interface TimedSample {
   cts: number;
 }
 
-/** Samples at or after `start`, in presentation order. Frame `n` is element `n - 1`. */
+/** Samples at or after `start` (all, if none), in presentation order. Frame `n` is element `n - 1`. */
 export function presentedInOrder<T extends TimedSample>(
   samples: readonly T[],
-  start: number,
+  start: number | undefined,
 ): T[] {
-  return samples.filter((s) => s.cts >= start).sort((a, b) => a.cts - b.cts);
+  const presented =
+    start === undefined ? [...samples] : samples.filter((s) => s.cts >= start);
+  return presented.sort((a, b) => a.cts - b.cts);
 }

--- a/app/packages/video-annotation/src/streams/editList.ts
+++ b/app/packages/video-annotation/src/streams/editList.ts
@@ -3,35 +3,21 @@
  */
 
 /**
- * Edit-list (`elst`) handling for the native decode path.
- *
- * An mp4 edit list tells players where in the stored media presentation
- * begins. Encoders commonly write one to absorb start-up latency, so the first
- * stored picture(s) sit before the presentation start. ffmpeg (and therefore
- * OpenCV, `to_frames`, and any downstream pipeline that decodes with them)
- * treats such samples as pre-roll: they are decoded for reference but never
- * emitted, and frame 1 is the first sample at or after the edit start. Frame
- * numbers written by Annotate must follow the same rule or they land one
- * frame off in every consumer's decode.
- *
- * Pure functions — no mp4box, no workers — so the rule is unit-testable.
+ * mp4 edit-list (`elst`) numbering. Samples before the edit list's media start
+ * are pre-roll: ffmpeg decodes them for reference and never emits them, so
+ * frame 1 is the first sample at or after the start. `to_frames`, OpenCV, and
+ * backend inference inherit that numbering; Annotate must match it.
  */
 
-/** One `elst` entry as mp4box exposes it on `Track.edits`. */
+/** One `elst` entry, as mp4box exposes it on `Track.edits`. */
 export interface EditListEntry {
-  /** Duration of the edit in the presentation, in movie timescale units. */
+  /** Movie timescale units. */
   segment_duration: number;
-  /**
-   * Media time where this edit starts, in track timescale units. `-1` marks an
-   * empty edit (a gap in the presentation with no media).
-   */
+  /** Track timescale units; `-1` marks an empty edit. */
   media_time: number;
 }
 
-/**
- * Media time (track timescale units) at which presentation begins: the
- * `media_time` of the first non-empty edit, or `0` when there is no edit list.
- */
+/** Media time where presentation begins: the first non-empty edit's `media_time`, else 0. */
 export function presentationStart(
   edits: readonly EditListEntry[] | undefined,
 ): number {
@@ -48,17 +34,12 @@ export function presentationStart(
   return 0;
 }
 
-/** The composition timestamp of a sample, in track timescale units. */
+/** Sample composition time, in track timescale units. */
 export interface TimedSample {
   cts: number;
 }
 
-/**
- * The samples that receive frame numbers, in presentation order: every sample
- * whose composition time is at or after `start`, sorted ascending by `cts`.
- * Samples before `start` are pre-roll — decoded when a GOP needs them, never
- * numbered. Frame `n` is `presentedInOrder(...)[n - 1]`.
- */
+/** Samples at or after `start`, in presentation order. Frame `n` is element `n - 1`. */
 export function presentedInOrder<T extends TimedSample>(
   samples: readonly T[],
   start: number,

--- a/app/packages/video-annotation/src/streams/mp4box.d.ts
+++ b/app/packages/video-annotation/src/streams/mp4box.d.ts
@@ -41,6 +41,15 @@ declare module "mp4box" {
     track_width: number;
     track_height: number;
     type?: "audio" | "video" | "subtitles" | "metadata";
+    /** The track's `elst` entries, when it has an edit list. */
+    edits?: Array<{
+      /** Presentation duration of the edit, in movie timescale units. */
+      segment_duration: number;
+      /** Media start of the edit in track timescale units; `-1` = empty edit. */
+      media_time: number;
+      media_rate_integer: number;
+      media_rate_fraction: number;
+    }>;
   }
 
   export interface Movie {

--- a/app/packages/video-annotation/src/streams/mp4box.d.ts
+++ b/app/packages/video-annotation/src/streams/mp4box.d.ts
@@ -41,11 +41,11 @@ declare module "mp4box" {
     track_width: number;
     track_height: number;
     type?: "audio" | "video" | "subtitles" | "metadata";
-    /** The track's `elst` entries, when it has an edit list. */
+    /** `elst` entries, when the track has an edit list. */
     edits?: Array<{
-      /** Presentation duration of the edit, in movie timescale units. */
+      /** Movie timescale units. */
       segment_duration: number;
-      /** Media start of the edit in track timescale units; `-1` = empty edit. */
+      /** Track timescale units; `-1` marks an empty edit. */
       media_time: number;
       media_rate_integer: number;
       media_rate_fraction: number;

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -23,8 +23,7 @@
  * stamp every `EncodedVideoChunk` with that timestamp; the decoder echoes it
  * onto the output `VideoFrame`, so we can assign the correct frame number on
  * the way out regardless of decode order (B-frames) or GOP boundaries. Frame
- * 1 is the first sample at/after the edit list's presentation start — the
- * same numbering ffmpeg, `to_frames`, and backend inference use.
+ * 1 is the first sample at or after the edit list's start, as in ffmpeg.
  *
  * GOP handling lives entirely here (the stream base stays source-agnostic): a
  * chunk request for presentation frames `[start, start+n)` is snapped back to
@@ -325,15 +324,10 @@ async function streamMoov(
 }
 
 /**
- * Turn raw demuxed samples into `decodeOrder` (decode order, as delivered),
- * assign each presented sample its 1-indexed presentation frame number (sort
- * by `cts`), and build the µs→frame map + keyframe index list.
- *
- * Samples before the edit list's presentation start are pre-roll (see
- * {@link ./editList}): they stay in `decodeOrder` because the GOP's keyframe
- * is usually among them, but they get no frame number, so their decoded
- * output is dropped in {@link onDecoderOutput}. This is ffmpeg's numbering,
- * which is what `to_frames` and backend inference see.
+ * Build `decodeOrder` (as delivered), number the presented samples 1..N by
+ * `cts`, and index keyframes. Pre-roll samples stay in `decodeOrder` — the GOP
+ * keyframe is usually one — but get no frame number, so {@link onDecoderOutput}
+ * drops their output.
  */
 function buildSampleTable(
   samples: Sample[],
@@ -341,7 +335,7 @@ function buildSampleTable(
   edits: readonly EditListEntry[] | undefined,
 ): void {
   decodeOrder = samples.map((s, decodeIndex) => ({
-    frameNumber: 0, // pre-roll samples keep 0
+    frameNumber: 0,
     decodeIndex,
     tsMicros: Math.round((s.cts * 1e6) / timescale),
     durMicros: Math.round((s.duration * 1e6) / timescale),

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -22,7 +22,9 @@
  * each frame's presentation timestamp (`cts`) to a 1-indexed frame number. We
  * stamp every `EncodedVideoChunk` with that timestamp; the decoder echoes it
  * onto the output `VideoFrame`, so we can assign the correct frame number on
- * the way out regardless of decode order (B-frames) or GOP boundaries.
+ * the way out regardless of decode order (B-frames) or GOP boundaries. Frame
+ * 1 is the first sample at/after the edit list's presentation start — the
+ * same numbering ffmpeg, `to_frames`, and backend inference use.
  *
  * GOP handling lives entirely here (the stream base stays source-agnostic): a
  * chunk request for presentation frames `[start, start+n)` is snapped back to
@@ -44,6 +46,11 @@ import type {
   FrameWorkerOutbound,
   InitMessage,
 } from "./frameWorkerProtocol";
+import {
+  type EditListEntry,
+  presentationStart,
+  presentedInOrder,
+} from "./editList";
 import {
   ByteRangeCache,
   type ByteRange,
@@ -207,7 +214,7 @@ async function initSampleTable(
     throw new Error("demux produced no samples");
   }
 
-  buildSampleTable(samples, track.timescale);
+  buildSampleTable(samples, track.timescale, track.edits);
 }
 
 /**
@@ -319,12 +326,22 @@ async function streamMoov(
 
 /**
  * Turn raw demuxed samples into `decodeOrder` (decode order, as delivered),
- * assign each its 1-indexed presentation frame number (sort by `cts`), and
- * build the µs→frame map + keyframe index list.
+ * assign each presented sample its 1-indexed presentation frame number (sort
+ * by `cts`), and build the µs→frame map + keyframe index list.
+ *
+ * Samples before the edit list's presentation start are pre-roll (see
+ * {@link ./editList}): they stay in `decodeOrder` because the GOP's keyframe
+ * is usually among them, but they get no frame number, so their decoded
+ * output is dropped in {@link onDecoderOutput}. This is ffmpeg's numbering,
+ * which is what `to_frames` and backend inference see.
  */
-function buildSampleTable(samples: Sample[], timescale: number): void {
+function buildSampleTable(
+  samples: Sample[],
+  timescale: number,
+  edits: readonly EditListEntry[] | undefined,
+): void {
   decodeOrder = samples.map((s, decodeIndex) => ({
-    frameNumber: 0, // filled below once we know presentation order
+    frameNumber: 0, // pre-roll samples keep 0
     decodeIndex,
     tsMicros: Math.round((s.cts * 1e6) / timescale),
     durMicros: Math.round((s.duration * 1e6) / timescale),
@@ -333,9 +350,12 @@ function buildSampleTable(samples: Sample[], timescale: number): void {
     size: s.size,
   }));
 
-  // Presentation order = ascending composition timestamp. 1-indexed frame
-  // numbers match `to_frames` / looker's ImaVid numbering (frame 1 = t≈0).
-  byFrameNumber = [...decodeOrder].sort((a, b) => a.tsMicros - b.tsMicros);
+  const presented = presentedInOrder(
+    samples.map((s, decodeIndex) => ({ cts: s.cts, decodeIndex })),
+    presentationStart(edits),
+  );
+
+  byFrameNumber = presented.map((p) => decodeOrder[p.decodeIndex]);
   byFrameNumber.forEach((sample, i) => {
     sample.frameNumber = i + 1;
     microsToFrame.set(sample.tsMicros, sample.frameNumber);
@@ -345,7 +365,7 @@ function buildSampleTable(samples: Sample[], timescale: number): void {
     .filter((s) => s.isSync)
     .map((s) => s.decodeIndex);
 
-  totalFrames = decodeOrder.length;
+  totalFrames = byFrameNumber.length;
 }
 
 /**


### PR DESCRIPTION
## 🔗 Related Issues

FOEPD-4580 (Explore/Annotate frame offsets). Second trigger, distinct from the dropped-frame case.

## 📋 What changes are proposed in this pull request?

Native-decode Annotate now numbers frames from the mp4 edit list's presentation start, the way ffmpeg does.

An mp4 edit list (`elst`) tells players where in the stored media presentation begins. Encoders commonly write one to absorb start-up latency, so the first stored picture sits before the presentation start. ffmpeg treats such samples as pre-roll: decoded for reference, never emitted, with frame 1 being the first sample at or after the edit start. OpenCV, `to_frames`, and backend inference inherit that numbering. Annotate numbered every stored sample instead, so on such a video its frame `n` was picture `n` while every other consumer's frame `n` was picture `n+1`, and labels drawn in Annotate landed one frame off in the customer's own decode.

A customer file surfaced this: 46 stored pictures at an even 5 fps, edit list starting 0.08 s in, ffmpeg and `to_frames` yield 45 frames starting at picture 2.

- `editList.ts`: pure helpers. `presentationStart` reads the first non-empty edit's `media_time`; `presentedInOrder` returns the samples at or after it sorted by composition time.
- `videoDecodeWorker.ts`: `buildSampleTable` numbers only presented samples. Pre-roll samples stay in decode order because the GOP keyframe is usually among them, but get no frame number, so `onDecoderOutput` drops their output. `totalFrames` is the presented count.
- `mp4box.d.ts`: expose `Track.edits`, which mp4box already populates.

Videos without an edit list, or with `media_time` 0, are unaffected.

Not in this PR: Explore's numbering (rides the FOEPD-4580 sample-table work) and eta's `total_frame_count`, which still reports the stored-sample count.

## 🧪 How is this patch tested? If it is not, please explain why.

- New `editList.test.ts`: no edit list, leading empty edit, all-empty edits, pre-roll exclusion at the customer file's exact values, boundary at the edit start, B-frame reordering, input not mutated.
- `yarn vitest run packages/video-annotation`: 40 files, 362 tests pass.
- Package typecheck and eslint: no new errors.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Video annotation frame numbers now match ffmpeg on videos whose mp4 edit list trims the start of the media, so labels line up with frames extracted by `to_frames` and OpenCV.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native video playback for MP4 files with edit lists.
  * Excluded pre-roll samples from displayed frame numbering while preserving correct decoding order.
  * Updated total frame counts to reflect presented frames only.
  * Improved presentation timing and ordering at edit-list boundaries.

* **Tests**
  * Added coverage for presentation timing, sample ordering, empty edits, pre-roll filtering, boundary handling, and input immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4032
<!-- enterprise-sync-pr:end -->