### PR TITLE
Fix ViewExpression slicing for mixed-sign start/stop bounds

### DIFF
--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2300,9 +2300,6 @@ class ViewExpression(object):
         # if the `if_else()` calls were replaced by explicit logic when
         # start/stop are numbers, not expressions
 
-        # @todo slices like `x[-a:b]` where sign(a) != sign(b) are not
-        # currently working
-
         if s.start is not None:
             position = s.start
             if s.stop is None:
@@ -2310,13 +2307,35 @@ class ViewExpression(object):
                 expr = ViewExpression({"$slice": [self, position, n]})
                 return self.let_in(expr)
 
-            n = s.stop - position
+            stop = s.stop
+            length = self.length()
 
-            pos_start = ViewExpression({"$slice": [self, position, n]})
-            neg_start = ViewExpression(
-                {"$slice": [self, position + self.length(), n]}
+            # `n` (the number of elements to take) must be computed from
+            # the absolute, length-resolved positions of both bounds,
+            # since `stop - position` is only correct when `position` and
+            # `stop` share the same sign (eg `x[-a:b]` where sign(a) !=
+            # sign(b) would otherwise be wrong)
+            resolved_position = ViewExpression(position >= 0).if_else(
+                position, position + length
             )
-            expr = ViewExpression(n >= 0).if_else(
+            resolved_stop = ViewExpression(stop >= 0).if_else(
+                stop, stop + length
+            )
+            n = resolved_stop - resolved_position
+
+            # MongoDB's `$slice` requires a strictly positive count, so a
+            # non-positive `n` (eg `x[5:5]`, an empty result) must take the
+            # `$literal: []` branch below rather than reach `$slice` with
+            # `n <= 0`, which would raise rather than yield `[]`. The count
+            # passed to `$slice` itself is clamped to be safe to evaluate
+            # even when this branch isn't the one ultimately selected.
+            n_safe = ViewExpression({"$max": [n, 1]})
+
+            pos_start = ViewExpression({"$slice": [self, position, n_safe]})
+            neg_start = ViewExpression(
+                {"$slice": [self, position + length, n_safe]}
+            )
+            expr = ViewExpression(n > 0).if_else(
                 ViewExpression(position >= 0).if_else(pos_start, neg_start),
                 ViewExpression({"$literal": []}),
             )

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -777,6 +777,32 @@ class ViewExpressionTests(unittest.TestCase):
         self.assertListEqual(slices, manual_slices)
 
     @drop_datasets
+    def test_array_slice_mixed_sign(self):
+        dataset = fo.Dataset()
+        dataset.add_sample(
+            fo.Sample(filepath="filepath1.jpg", my_int_list=list(range(10)))
+        )
+
+        # Slices where the start and stop bounds have different signs
+        # (eg `x[-a:b]`) previously computed the wrong slice length
+        slices = [
+            (-3, 8),
+            (3, -2),
+            (-8, 9),
+            (-20, 20),
+            (20, -20),
+            (0, -10),
+            (5, 5),
+            (7, 2),
+        ]
+        for start, stop in slices:
+            expected = [list(range(10))[start:stop]]
+            actual = dataset.values(F("my_int_list")[start:stop])
+            self.assertListEqual(
+                actual, expected, "slice [%d:%d]" % (start, stop)
+            )
+
+    @drop_datasets
     def test_str(self):
         special_chars = r"[]{}()*+-?.,\\^$|#"
 


### PR DESCRIPTION
Not tied to a filed issue — the code already flagged this itself:

```python
# @todo slices like `x[-a:b]` where sign(a) != sign(b) are not
# currently working
```

That comment in `ViewExpression.__getitem__` (`fiftyone/core/expressions.py`)
has been sitting there unaddressed. Confirmed it's a real, live bug, not
just a stale note.

## The bug

`x[start:stop]` on a list-valued `ViewExpression` (eg `F("bounding_box")[a:b]`,
used throughout filtering/aggregation) computes the MongoDB `$slice` count as
`n = stop - start`, using the raw values. That's only correct when `start`
and `stop` share a sign — for a mixed-sign slice it silently returns the
**wrong data**, not an error:

```py
data = list(range(10))

data[-3:8]   # Python: [7]
# F("nums")[-3:8] on the same data: [7, 8, 9]  (wrong)

data[3:-2]   # Python: [3, 4, 5, 6, 7]
# F("nums")[3:-2]: []  (wrong)
```

## Fix

`n` is now computed from the length-resolved absolute positions of both
bounds (adding `length()` to a negative bound before subtracting), so it
matches Python's own slicing semantics regardless of sign, rather than only
working when both bounds happen to agree.

While verifying this against a full sweep of sign/bound combinations, I hit
a second, related issue exposed by the fix: MongoDB's `$slice` requires a
*strictly positive* count, so slices that legitimately resolve to an empty
result (eg `x[5:5]`) would raise an aggregation error instead of returning
`[]`. This already existed on `develop`/`community` for the "both bounds
equal" case (`n == 0` under the *old*, buggy formula too — verified this
independently reproduces on unmodified code), but the corrected `n`
computation lands on exactly `0` for legitimate empty-result slices more
often, so it's addressed here too: the count passed to `$slice` is only
used when `n > 0`, with the empty case routed to a `$literal: []` branch
instead.

## Testing

- Reproduced the original bug against a real MongoDB instance, comparing
  `F("nums")[start:stop]` to Python's own `list[start:stop]` on identical
  data, across 26 start/stop combinations (all four sign pairings, equal
  bounds, out-of-range bounds, one-sided slices, `None`/`None`).
- Verified the `n == 0` MongoDB error reproduces identically on unmodified
  `community` (via `git stash`), confirming it's pre-existing and not
  introduced by this change.
- Added `test_array_slice_mixed_sign` to `tests/unittests/view_tests.py`,
  covering the mixed-sign cases plus the empty-result edge case, following
  the existing `test_array`'s pattern of comparing against native Python
  slicing.
- Ran `view_tests.py` (107 tests) and `aggregation_tests.py` (25 tests)
  locally against a real MongoDB instance — all passing.
- black/pylint clean.
