### PR TITLE
Media source location tests resolve paths before comparing them

### DIFF
--- a/tests/unittests/multimodal/lerobot_tests.py
+++ b/tests/unittests/multimodal/lerobot_tests.py
@@ -185,6 +185,13 @@ def _source_locs(dataset):
     }
 
 
+def _located(path):
+    """A path as the platform resolves it. A recorded location is stored
+    with forward slashes and the path a test spelled carries the platform's
+    separators, case and short names; both resolve to the same place."""
+    return os.path.normcase(os.path.realpath(path))
+
+
 def _take_sources(dataset):
     """Removes and returns the dataset's media sources: what an unbound
     source looks like to everything downstream."""
@@ -317,13 +324,17 @@ class LeRobotImporterTests(unittest.TestCase):
             try:
                 _put_sources(dataset, entries, loc=relocated_root)
                 locs = _source_locs(dataset)
-                self.assertEqual(locs[episode.source_id], relocated_root)
+                self.assertEqual(
+                    _located(locs[episode.source_id]), _located(relocated_root)
+                )
                 resolved = fmm._resolve_media_references(
                     dataset, {"e": episode.to_mongo()}
                 )["e"].assets
                 self.assertTrue(
                     all(
-                        asset.path.startswith(relocated_root)
+                        _located(asset.path).startswith(
+                            _located(relocated_root)
+                        )
                         and os.path.isfile(asset.path)
                         for asset in resolved
                     )
@@ -523,8 +534,8 @@ print(os.path.join(sources[source_id], *path.split('/')))
             # import records the source's real location, so that is what a
             # reader is handed back
             self.assertEqual(
-                run(),
-                os.path.join(os.path.realpath(root), "meta", "info.json"),
+                _located(run()),
+                _located(os.path.join(root, "meta", "info.json")),
             )
 
             entries = list(fmm._media_sources_by_id(dataset).values())
@@ -1164,7 +1175,8 @@ class MediaAssetLifecycleTests(unittest.TestCase):
             # a source this import created resolves through the bundle's
             # copy, not the exporting machine's location
             self.assertEqual(
-                _source_locs(imported)[source["id"]], bundle_source_root
+                _located(_source_locs(imported)[source["id"]]),
+                _located(bundle_source_root),
             )
 
     @drop_datasets
@@ -1243,9 +1255,9 @@ class MediaAssetLifecycleTests(unittest.TestCase):
             )
             # the bundle rebinds the source onto itself, not the original
             self.assertTrue(
-                _source_locs(materialized_import)[
-                    reference.source_id
-                ].startswith(os.path.realpath(materialized_root))
+                _located(
+                    _source_locs(materialized_import)[reference.source_id]
+                ).startswith(_located(materialized_root))
             )
             self.assertNotIn(
                 "media_reference_sources", materialized_import.info

--- a/tests/unittests/multimodal/media_reference_tests.py
+++ b/tests/unittests/multimodal/media_reference_tests.py
@@ -45,7 +45,6 @@ from fiftyone.utils.lerobot import (
 import fiftyone.types as fot
 import fiftyone.utils.data as foud
 
-
 # One source key per kind: a sample's key names its source, and the source
 # entry on the dataset is what says which kind that is.
 _SOURCE_KEY = "a1b2c3d4e5f6"
@@ -98,6 +97,13 @@ def _make_reference(episode_index, source=_SOURCE_KEY):
         videos={"camera": [0, 0, float(episode_index), episode_index + 1.0]},
         tasks=["demo"],
     )
+
+
+def _located(path):
+    """A path as the platform resolves it. A recorded location is stored
+    with forward slashes and the path a test spelled carries the platform's
+    separators, case and drive; both resolve to the same place."""
+    return os.path.normcase(os.path.realpath(path))
 
 
 def _record_source(dataset, kind=LEROBOT_EPISODE_KIND, key=_SOURCE_KEY):
@@ -867,7 +873,8 @@ class MediaReferenceDatasetTests(unittest.TestCase):
         recorded = fmm._media_sources_by_id(destination)
         self.assertEqual(set(recorded), {_SOURCE_KEY, bundled_key})
         self.assertEqual(
-            recorded[bundled_key]["loc"], "/tmp/media-source-%s" % bundled_key
+            _located(recorded[bundled_key]["loc"]),
+            _located("/tmp/media-source-%s" % bundled_key),
         )
 
     @drop_datasets
@@ -1399,7 +1406,9 @@ class MediaReferenceDatasetTests(unittest.TestCase):
 
         # and every caller still reads one self-contained description
         entries = fmm._media_sources_by_id(dataset)
-        self.assertEqual(entries["a"]["loc"], "/tmp/sources/a")
+        self.assertEqual(
+            _located(entries["a"]["loc"]), _located("/tmp/sources/a")
+        )
         self.assertEqual(entries["a"]["data_path"], layout["data_path"])
         self.assertEqual(entries["a"]["kind"], LEROBOT_EPISODE_KIND)
         self.assertTrue(entries["a"]["statistics"])


### PR DESCRIPTION
## 🔗 Related Issues

Follow-up to #8397.

## 📋 What changes are proposed in this pull request?

Six tests in `lerobot_tests.py` and `media_reference_tests.py` fail on Windows since #8397. A recorded media source location is stored with forward slashes, the way sample filepaths are, while the tests compare it to the path they spelled with the platform's separators, drive letter, and short names (`C:/Users/RUNNER~1/...` vs `C:\Users\runneradmin\...`, `D:/tmp/sources/a` vs `/tmp/sources/a`).

Each test module gets a `_located()` helper that resolves a path the way the platform does (`os.path.realpath` + `os.path.normcase`), and both sides of those comparisons go through it. Tests only, no source changes.

## 🧪 How is this patch tested? If it is not, please explain why.

The six tests pass locally on macOS. Windows CI on this PR is the real check; the same jobs fail on every PR that carries #8397 today.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

- [x] Other: tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for multimodal workflows across operating systems.
  - Path comparisons now consistently account for platform-specific separators, capitalization, drive letters, symbolic links, and path representations.
  - Added normalized location checks for relocation, subprocess execution, imported bundles, and media sources.
  - These updates reduce false test failures caused by differences in how platforms represent file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4036
<!-- enterprise-sync-pr:end -->