### PR TITLE
The relocated source binding test resolves paths before comparing them

### DIFF
--- a/tests/unittests/multimodal/lerobot_tests.py
+++ b/tests/unittests/multimodal/lerobot_tests.py
@@ -546,8 +546,10 @@ print(os.path.join(sources[source_id], *path.split('/')))
                 # a process that recorded nothing reads the source's current
                 # location out of the dataset, not a location it remembered
                 self.assertEqual(
-                    run(),
-                    os.path.join(relocated_root, "meta", "info.json"),
+                    _located(run()),
+                    _located(
+                        os.path.join(relocated_root, "meta", "info.json")
+                    ),
                 )
 
             _put_sources(dataset, entries)


### PR DESCRIPTION
## 🔗 Related Issues

Follow-up to #8413.

## 📋 What changes are proposed in this pull request?

#8413 wrapped the six Windows path comparisons that appeared in the CI log. `test_source_binding_survives_a_fresh_server_process` has a second comparison of the same shape a few lines after the first; it never ran while the first was failing, so it did not show up. Windows 3.10 still fails on it. This wraps that comparison in the same `_located()` resolver.

Both test modules were audited for any other comparison of a recorded location against a raw path; this is the only one left.

## 🧪 How is this patch tested? If it is not, please explain why.

The test passes locally on macOS. Windows CI on this PR is the real check.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.

### What areas of FiftyOne does this PR affect?

- [x] Other: tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relocation test reliability by comparing normalized paths across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4043
<!-- enterprise-sync-pr:end -->