### PR TITLE
ci: check Python formatting on pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
       e2e-changes: ${{ steps.filter.outputs.e2e-pw }}
       fiftyone-changes: ${{ steps.filter.outputs.fiftyone }}
       format-changes: ${{ steps.filter.outputs.format }}
+      python-changes: ${{ steps.filter.outputs.python }}
       run-ci: ${{ steps.gate.outputs.run-ci }}
       heavy: ${{ steps.gate.outputs.heavy }}
     steps:
@@ -75,6 +76,10 @@ jobs:
               - '**/*.css'
               - '**/*.scss'
               - '**/*.md'
+            python:
+              - '**/*.py'
+              - 'pyproject.toml'
+              - '.pre-commit-config.yaml'
 
       - name: Gate CI by base branch
         id: gate
@@ -142,6 +147,24 @@ jobs:
       needs.modified-files.outputs.format-changes == 'true')
     uses: ./.github/workflows/lint-app.yml
 
+  lint-python:
+    needs: modified-files
+    if: >-
+      needs.modified-files.outputs.run-ci == 'true' &&
+      needs.modified-files.outputs.python-changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Check black formatting
+        # pre-commit installs the black pinned in .pre-commit-config.yaml, so
+        # this check and the local hook agree on the version
+        run: |
+          pip install pre-commit
+          pre-commit run black --all-files --show-diff-on-failure
+
   test:
     needs: modified-files
     if: >-
@@ -176,7 +199,7 @@ jobs:
     # creates a suites-only comment instead; the e2e pipeline upgrades it in
     # place if it runs later.
     runs-on: ubuntu-latest
-    needs: [modified-files, build, lint, test, test-windows, e2e]
+    needs: [modified-files, build, lint, lint-python, test, test-windows, e2e]
     if: >-
       always() &&
       needs.modified-files.outputs.run-ci == 'true' &&
@@ -246,7 +269,7 @@ jobs:
 
   all-tests:
     runs-on: ubuntu-latest
-    needs: [modified-files, build, lint, test, e2e]
+    needs: [modified-files, build, lint, lint-python, test, e2e]
     # not `always()`: a concurrency-cancelled run (an edit displaced by the
     # next edit) must conclude cancelled, not turn the failed gate into a
     # red `all-tests` on a SHA it never tested.
@@ -310,7 +333,7 @@ jobs:
               // counts as a mirror only when its gate passed and every suite
               // job it spawned was skipped; anything ambiguous (gate still
               // running, jobs not yet listed) stays blocking.
-              const SUITE = /^(build|lint|test|test-windows|e2e)\b/;
+              const SUITE = /^(build|lint|lint-python|test|test-windows|e2e)\b/;
               const live = [];
               for (const r of candidates) {
                 const jobs = await github.paginate(
@@ -408,5 +431,6 @@ jobs:
         run: sh -c ${{
           (needs.build.result == 'success' || needs.build.result == 'skipped') &&
           (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+          (needs.lint-python.result == 'success' || needs.lint-python.result == 'skipped') &&
           (needs.test.result == 'success' || needs.test.result == 'skipped') &&
           (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==21.12b0]
+        additional_dependencies: [black==26.5.1]
         args: ["-l 79"]
         exclude: ^docs/theme/|\.rst$
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
       - id: black
         language_version: python3

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -306,6 +306,7 @@ To disable pylint errors temporarily in a module:
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: enable=wildcard-import
 from builtins import *
+
 # pragma pylint: enable=redefined-builtin
 # pragma pylint: enable=wildcard-import
 ```

--- a/docs/scripts/generate_plugin_docs.py
+++ b/docs/scripts/generate_plugin_docs.py
@@ -522,15 +522,13 @@ myst:
             display_tags = self._format_model_tags(tags)
             display_tags.append("Plugin")
 
-            self._plugin_model_cards.append(
-                f"""
+            self._plugin_model_cards.append(f"""
 .. customcarditem::
     :header: {name}
     :description: {description}
     :link: models/{model_slug}.html
     :tags: {",".join(display_tags)}
-"""
-            )
+""")
             logger.info(f"Generated model docs for {name}")
 
     def extract_plugins_from_readme(self, readme_content: str) -> List[Plugin]:

--- a/docs/scripts/make_hf_dataset_docs.py
+++ b/docs/scripts/make_hf_dataset_docs.py
@@ -19,7 +19,6 @@ import requests
 import yaml
 from huggingface_hub import HfApi, hf_hub_url
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -155,9 +154,11 @@ class HFDatasetDocGenerator:
                     dataset = HFDataset(
                         id=dataset_info.id,
                         downloads=getattr(dataset_info, "downloads", 0) or 0,
-                        last_modified=dataset_info.last_modified.isoformat()
-                        if getattr(dataset_info, "last_modified", None)
-                        else "",
+                        last_modified=(
+                            dataset_info.last_modified.isoformat()
+                            if getattr(dataset_info, "last_modified", None)
+                            else ""
+                        ),
                         card_data=card_data,
                     )
                     datasets.append(dataset)
@@ -186,9 +187,11 @@ class HFDatasetDocGenerator:
 
         datasets.sort(
             key=lambda d: (
-                -datetime.fromisoformat(d.last_modified).timestamp()
-                if d.last_modified
-                else 0,
+                (
+                    -datetime.fromisoformat(d.last_modified).timestamp()
+                    if d.last_modified
+                    else 0
+                ),
                 -d.downloads,
             )
         )

--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -16,7 +16,6 @@ from jinja2 import Environment, BaseLoader
 import eta.core.utils as etau
 import fiftyone.zoo as foz
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -338,9 +338,9 @@ def _inject_page_meta(app, pagename, templatename, context, doctree):
         lines = app.config.llms_txt_description.splitlines()
         description = lines[0].lstrip("> ").strip() if lines else ""
     context["meta_description"] = description
-    context[
-        "markdown_url"
-    ] = f"{app.config.llms_txt_base_url.rstrip('/')}/{pagename}.md"
+    context["markdown_url"] = (
+        f"{app.config.llms_txt_base_url.rstrip('/')}/{pagename}.md"
+    )
 
 
 def setup(app):

--- a/docs/source/custom_directives.py
+++ b/docs/source/custom_directives.py
@@ -5,6 +5,7 @@ Sphinx custom directives.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import posixpath
 
 from docutils.parsers.rst import Directive, directives

--- a/docs/source/recipes/image_deduplication_helpers.py
+++ b/docs/source/recipes/image_deduplication_helpers.py
@@ -19,6 +19,7 @@ A random 5% of the samples are duplicates, instead of the original samples.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import random
 
@@ -29,7 +30,6 @@ import fiftyone.utils.image as foui
 
 fou.ensure_tf()
 from tensorflow.keras.datasets import cifar100  # pylint: disable=import-error
-
 
 DATASET_SIZE = 1000
 DATASET_DIR = os.path.join("/tmp/fiftyone/cifar100_with_duplicates")

--- a/docs/source/redirects.py
+++ b/docs/source/redirects.py
@@ -8,6 +8,7 @@ Inspired by https://github.com/sphinx-contrib/redirects.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import glob
 import json
 import os
@@ -17,7 +18,6 @@ from sphinx.builders import html as builders
 from sphinx.util import logging
 
 import eta.core.utils as etau
-
 
 logger = logging.getLogger(__name__)
 

--- a/docs/source/tutorials/query_flickr.py
+++ b/docs/source/tutorials/query_flickr.py
@@ -7,6 +7,7 @@ https://www.flickr.com/services/apps/create.
 Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
+
 import argparse
 from itertools import takewhile
 import os

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -13,7 +13,6 @@ from os import getenv
 from pkgutil import extend_path as _extend_path
 from sys import hexversion
 
-
 logger = logging.getLogger(__name__)
 
 #
@@ -31,7 +30,6 @@ __version__ = _foc.VERSION
 from fiftyone.__public__ import *
 
 import fiftyone.core.logging as _fol
-
 
 _fol.init_logging()
 

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -13,7 +13,6 @@ from packaging.version import Version
 
 from importlib.metadata import metadata
 
-
 CLIENT_TYPE = "fiftyone"
 
 FIFTYONE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -28,7 +28,6 @@ import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/core/annotation/attributes.py
+++ b/fiftyone/core/annotation/attributes.py
@@ -12,7 +12,6 @@ from enum import Enum
 from collections.abc import Generator
 from typing import Any, Literal, Optional, Union
 
-
 #: Maximum nesting depth allowed for a ``when`` condition tree. Mirrors the
 #: 20-level taxonomy depth limit cited in the PRD.
 MAX_CONDITION_DEPTH = 20

--- a/fiftyone/core/annotation/constants.py
+++ b/fiftyone/core/annotation/constants.py
@@ -14,7 +14,6 @@ import fiftyone.core.media as fom
 import fiftyone.core.metadata as fomm
 from fiftyone.core.odm import DynamicEmbeddedDocument
 
-
 ### Components
 
 

--- a/fiftyone/core/annotation/hydrate_label_schemas.py
+++ b/fiftyone/core/annotation/hydrate_label_schemas.py
@@ -16,7 +16,6 @@ from typing import Any
 
 import fiftyone.core.annotation.constants as foac
 
-
 logger = logging.getLogger(__name__)
 
 _SOURCE = "_source"

--- a/fiftyone/core/brain.py
+++ b/fiftyone/core/brain.py
@@ -5,6 +5,7 @@ Brain method runs framework.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from fiftyone.core.runs import (
     BaseRun,
     BaseRunConfig,

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -5,6 +5,7 @@ Clips views.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import deepcopy
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -49,7 +49,6 @@ import fiftyone.core.storage as fost
 import fiftyone.core.utils as fou
 from fiftyone.internal.docs import hide_from_docs
 
-
 fod = fou.lazy_import("fiftyone.core.dataset")
 foma = fou.lazy_import("fiftyone.multimodal.media_reference.asset_planning")
 fos = fou.lazy_import("fiftyone.core.stages")

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -51,7 +51,6 @@ import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 import fiftyone.migrations as fomi
 
-
 fot = fou.lazy_import("fiftyone.core.stages")
 foud = fou.lazy_import("fiftyone.utils.data")
 food = fou.lazy_import("fiftyone.operators.delegated")

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -5,6 +5,7 @@ Base classes for objects that are backed by database documents.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 
 from bson import ObjectId

--- a/fiftyone/core/evaluation.py
+++ b/fiftyone/core/evaluation.py
@@ -5,6 +5,7 @@ Evaluation runs framework.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from fiftyone.core.runs import (
     BaseRun,
     BaseRunInfo,

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2748,9 +2748,7 @@ class ViewExpression(object):
             array.sort({comp}){rev};
             return array;
         }}
-        """.format(
-            comp=comp, rev=rev
-        )
+        """.format(comp=comp, rev=rev)
 
         return self._function(sort_fcn)
 

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -23,7 +23,6 @@ import fiftyone.core.frame_utils as fofu
 import fiftyone.core.odm as foo
 import fiftyone.core.utils as fou
 
-
 fmm = fou.lazy_import("fiftyone.multimodal.media_reference.field_model")
 
 

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -5,6 +5,7 @@ Frame utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import numbers
 
 

--- a/fiftyone/core/groups.py
+++ b/fiftyone/core/groups.py
@@ -5,6 +5,7 @@ Sample groups.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 
 from bson import ObjectId

--- a/fiftyone/core/json.py
+++ b/fiftyone/core/json.py
@@ -5,6 +5,7 @@ FiftyOne JSON handling
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import dataclasses
 from datetime import date, datetime
 import math
@@ -13,7 +14,6 @@ from bson import ObjectId
 import numpy as np
 
 import fiftyone.core.utils as fou
-
 
 _MASK_CLASSES = {"Detection", "Heatmap", "Segmentation"}
 

--- a/fiftyone/core/map/batcher/__init__.py
+++ b/fiftyone/core/map/batcher/__init__.py
@@ -12,7 +12,6 @@ from fiftyone.core.map.batcher.batch import SampleBatch
 from fiftyone.core.map.batcher.id_batch import SampleIdBatch
 from fiftyone.core.map.batcher.slice_batch import SampleSliceBatch
 
-
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [
     k

--- a/fiftyone/core/map/mapper.py
+++ b/fiftyone/core/map/mapper.py
@@ -31,7 +31,9 @@ from fiftyone.core.map.typing import SampleCollection
 
 T = TypeVar("T")  # Sample type
 R = TypeVar("R")  # Return value type of map_fcn
-U = TypeVar("U")  # Return value type of iter_fcn if set - must be same as input type to map_fcn.
+U = TypeVar(
+    "U"
+)  # Return value type of iter_fcn if set - must be same as input type to map_fcn.
 
 
 logger = logging.getLogger(__name__)
@@ -160,9 +162,6 @@ class Mapper(abc.ABC):
         else:
             if save is True:
                 logger.warning("Unable to save when `iter_fcn` is provided")
-                
-        
-
 
         yield from self._map_samples(
             sample_collection,

--- a/fiftyone/core/map/typing.py
+++ b/fiftyone/core/map/typing.py
@@ -10,7 +10,6 @@ from typing import Iterator, List, Literal, Protocol, TypeVar
 
 import bson
 
-
 T = TypeVar("T")
 R = TypeVar("R")
 

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -74,9 +74,7 @@ class Metadata(DynamicEmbeddedDocument):
 
         with requests.get(url, stream=True) as r:
             r.raise_for_status()
-            size_bytes = fou.ResponseStream(
-                r, chunk_size=2**10
-            ).consume_size()
+            size_bytes = fou.ResponseStream(r, chunk_size=2**10).consume_size()
 
         return cls(size_bytes=size_bytes, mime_type=mime_type)
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -571,9 +571,11 @@ def _apply_image_model_to_frames_single(
                             frame = sample.frames[video_reader.frame_number]
 
                             _field_mapping = {
-                                k: v[len("frames.") :]
-                                if v.startswith("frames.")
-                                else v
+                                k: (
+                                    v[len("frames.") :]
+                                    if v.startswith("frames.")
+                                    else v
+                                )
                                 for k, v in field_mapping.items()
                             }
 
@@ -678,9 +680,11 @@ def _apply_image_model_to_frames_batch(
                             # This will be removed in the future when GetItem/dataloaders support video readers.
                             _frames = [sample.frames[fn] for fn in fns]
                             _field_mapping = {
-                                k: v[len("frames.") :]
-                                if v.startswith("frames.")
-                                else v
+                                k: (
+                                    v[len("frames.") :]
+                                    if v.startswith("frames.")
+                                    else v
+                                )
                                 for k, v in field_mapping.items()
                             }
 

--- a/fiftyone/core/odm/embedded_document.py
+++ b/fiftyone/core/odm/embedded_document.py
@@ -5,6 +5,7 @@ Base classes for documents that back dataset contents.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import re
 import mongoengine
 

--- a/fiftyone/core/odm/frame.py
+++ b/fiftyone/core/odm/frame.py
@@ -5,6 +5,7 @@ Backing document classes for :class:`fiftyone.core.frame.Frame` instances.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import OrderedDict
 
 from bson import ObjectId

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -646,9 +646,9 @@ class DatasetMixin(object):
             if path in label_schemas:
                 new_label_schemas[new_path] = new_label_schemas.pop(path)
                 if path in active_label_schemas:
-                    active_label_schemas[
-                        active_label_schemas.index(path)
-                    ] = new_path
+                    active_label_schemas[active_label_schemas.index(path)] = (
+                        new_path
+                    )
                 continue
 
             for field in label_schemas:

--- a/fiftyone/core/odm/runs.py
+++ b/fiftyone/core/odm/runs.py
@@ -5,6 +5,7 @@ Dataset run documents.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from mongoengine import FileField
 
 from fiftyone.core.fields import (

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -60,7 +60,6 @@ import fiftyone.core.storage as fos
 from .document import Document, SerializableDocument
 from .mixins import DatasetMixin, get_default_fields, NoDatasetMixin
 
-
 # Use our own Random object to avoid messing with the user's seed
 _random = random.Random()
 

--- a/fiftyone/core/odm/views.py
+++ b/fiftyone/core/odm/views.py
@@ -5,6 +5,7 @@ Saved view documents.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from fiftyone.core.fields import (
     ColorField,
     DateTimeField,

--- a/fiftyone/core/ontology_validation.py
+++ b/fiftyone/core/ontology_validation.py
@@ -14,7 +14,6 @@ from fiftyone.core.annotation.attributes import (
 from fiftyone.core.annotation.nodes import Node
 from fiftyone.core.ontology import AnnotationOntology, Taxonomy
 
-
 _ALLOWED_THEN_KEYS = {"values", "component"}
 
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -5,6 +5,7 @@ Patches views.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import deepcopy
 
@@ -21,7 +22,6 @@ import fiftyone.core.odm as foo
 import fiftyone.core.sample as fos
 import fiftyone.core.validation as fova
 import fiftyone.core.view as fov
-
 
 _PATCHES_TYPES = (fol.Detections, fol.Polylines, fol.Keypoints)
 _NO_MATCH_ID = ""

--- a/fiftyone/core/plots/__init__.py
+++ b/fiftyone/core/plots/__init__.py
@@ -5,6 +5,7 @@ Plotting framework.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .base import (

--- a/fiftyone/core/plots/base.py
+++ b/fiftyone/core/plots/base.py
@@ -5,13 +5,13 @@ Base plotting definitions.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 
 import fiftyone.core.context as foc
 import fiftyone.core.labels as fol
 import fiftyone.core.patches as fop
 import fiftyone.core.video as fov
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -5,6 +5,7 @@ Session plot manager.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import datetime
 import itertools
 import logging
@@ -19,7 +20,6 @@ import fiftyone.core.patches as fop
 import fiftyone.core.video as fov
 
 from .base import ResponsivePlot, ViewPlot, InteractivePlot
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -5,6 +5,7 @@ Matplotlib plots.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import logging
 
@@ -31,7 +32,6 @@ from .utils import (
     parse_locations,
     parse_scatter_inputs,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -5,6 +5,7 @@ Plotly plots.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 import itertools
 import logging
@@ -30,7 +31,6 @@ from .utils import (
     parse_locations,
     parse_scatter_inputs,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/core/plots/utils.py
+++ b/fiftyone/core/plots/utils.py
@@ -5,6 +5,7 @@ Plotting utils.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import warnings
 

--- a/fiftyone/core/plots/views.py
+++ b/fiftyone/core/plots/views.py
@@ -5,6 +5,7 @@ Plotly-powered view plots.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 from operator import itemgetter
 
@@ -19,7 +20,6 @@ import fiftyone.core.aggregations as foa
 
 from .base import ViewPlot
 from .plotly import PlotlyWidgetMixin
-
 
 _DEFAULT_LAYOUT = dict(
     template="ggplot2", margin={"r": 0, "t": 30, "l": 0, "b": 0}

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -5,6 +5,7 @@ Dataset runs framework.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import copy, deepcopy
 import datetime
 import logging
@@ -18,7 +19,6 @@ import fiftyone.constants as foc
 from fiftyone.core.config import Config, Configurable
 from fiftyone.core.odm import patch_runs
 from fiftyone.core.odm.runs import RunDocument
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -25,7 +25,6 @@ import fiftyone.core.utils as fou
 fmm = fou.lazy_import("fiftyone.multimodal.media_reference.field_model")
 import fiftyone.core.media_reference as fmd
 
-
 #: The stored field, which the hydrating property of the same name shadows
 _REFERENCE_FIELDS = ("media_reference",)
 

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -22,7 +22,6 @@ import fiftyone.core.config as focn
 import fiftyone.core.context as focx
 import fiftyone.service.util as fosu
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/core/session/__init__.py
+++ b/fiftyone/core/session/__init__.py
@@ -5,6 +5,7 @@ Session definitions for interacting with the FiftyOne App.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .session import close_app, launch_app, Session

--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -29,7 +29,6 @@ from fiftyone.core.session.events import (
     dict_factory,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/core/session/notebooks.py
+++ b/fiftyone/core/session/notebooks.py
@@ -5,6 +5,7 @@ Session notebook handling.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from dataclasses import dataclass
 import os
 import typing as t

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -66,7 +66,6 @@ from fiftyone.core.session.events import (
 )
 import fiftyone.core.session.notebooks as fosn
 
-
 logger = logging.getLogger(__name__)
 
 #
@@ -1340,29 +1339,29 @@ def _attach_listeners(session: "Session"):
         "set_label_selection_style", on_set_label_selection_style
     )
 
-    on_select_labels: t.Callable[
-        [SelectLabels], None
-    ] = lambda event: _on_select_labels(session._state, event)
+    on_select_labels: t.Callable[[SelectLabels], None] = (
+        lambda event: _on_select_labels(session._state, event)
+    )
     session._client.add_event_listener("select_labels", on_select_labels)
 
-    on_set_color_scheme: t.Callable[
-        [SetColorScheme], None
-    ] = lambda event: setattr(session._state, "color_scheme", event.to_odm())
+    on_set_color_scheme: t.Callable[[SetColorScheme], None] = (
+        lambda event: setattr(session._state, "color_scheme", event.to_odm())
+    )
     session._client.add_event_listener("set_color_scheme", on_set_color_scheme)
 
-    on_set_dataset_color_scheme: t.Callable[
-        [SetDatasetColorScheme], None
-    ] = lambda _: _on_refresh(session, None)
+    on_set_dataset_color_scheme: t.Callable[[SetDatasetColorScheme], None] = (
+        lambda _: _on_refresh(session, None)
+    )
     session._client.add_event_listener(
         "set_dataset_color_scheme", on_set_dataset_color_scheme
     )
 
-    on_set_group_slice: t.Callable[
-        [SetGroupSlice], None
-    ] = lambda event: setattr(
-        session._state.dataset,
-        "group_slice",
-        event.slice,
+    on_set_group_slice: t.Callable[[SetGroupSlice], None] = (
+        lambda event: setattr(
+            session._state.dataset,
+            "group_slice",
+            event.slice,
+        )
     )
     session._client.add_event_listener("set_group_slice", on_set_group_slice)
 

--- a/fiftyone/core/session/templates.py
+++ b/fiftyone/core/session/templates.py
@@ -5,8 +5,8 @@ Notebook Session HTML templates
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from jinja2 import Template
 
+from jinja2 import Template
 
 SCREENSHOT_STYLE = """
 @import url("https://fonts.googleapis.com/css2?family=Palanquin&display=swap");
@@ -88,14 +88,11 @@ SCREENSHOT_DIV = """
 """
 
 
-SCREENSHOT_HTML = Template(
-    """
+SCREENSHOT_HTML = Template("""
 <style>%s</style>
 %s
 <script type="text/javascript">%s</script>
-"""
-    % (SCREENSHOT_STYLE, SCREENSHOT_DIV, SCREENSHOT_SCRIPT)
-)
+""" % (SCREENSHOT_STYLE, SCREENSHOT_DIV, SCREENSHOT_SCRIPT))
 
 
 SCREENSHOT_COLAB = """
@@ -168,8 +165,7 @@ SCREENSHOT_DATABRICKS_SCRIPT = """
    })();
 """
 
-SCREENSHOT_DATABRICKS = Template(
-    """
+SCREENSHOT_DATABRICKS = Template("""
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -187,6 +183,4 @@ SCREENSHOT_DATABRICKS = Template(
     <script type="text/javascript">%s</script>
   </body>
 </html>
-"""
-    % (SCREENSHOT_STYLE, SCREENSHOT_DIV, SCREENSHOT_DATABRICKS_SCRIPT)
-)
+""" % (SCREENSHOT_STYLE, SCREENSHOT_DIV, SCREENSHOT_DATABRICKS_SCRIPT))

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -31,7 +31,6 @@ import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 from fiftyone.server.scalars import JSON
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/core/threed/camera.py
+++ b/fiftyone/core/threed/camera.py
@@ -12,7 +12,6 @@ from typing import Literal, Optional, Union
 from .transformation import Vector3, Vec3UnionType, normalize_to_vec3
 from .validators import BaseValidatedDataClass, validate_choice, validate_float
 
-
 UP_DIRECTIONS = frozenset(["X", "Y", "Z", "-X", "-Y", "-Z"])
 UpDirection = Literal["X", "Y", "Z", "-X", "-Y", "-Z"]
 

--- a/fiftyone/core/threed/transformation.py
+++ b/fiftyone/core/threed/transformation.py
@@ -12,7 +12,6 @@ from .validators import (
     validate_list,
 )
 
-
 EULER_AXES_SEQUENCES = frozenset(["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"])
 EulerAxesSequence = Literal["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]
 

--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -5,6 +5,7 @@ Simple validator utilities
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import re
 from typing import Any, Optional
 

--- a/fiftyone/core/uid.py
+++ b/fiftyone/core/uid.py
@@ -5,12 +5,12 @@ Utilities for usage analytics.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 import uuid
 
 import fiftyone.constants as foc
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -52,7 +52,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 import asyncio
 
-
 try:
     import pprintpp as _pprint
     from mongoengine.base.datastructures import BaseDict, BaseList
@@ -80,7 +79,6 @@ import eta.core.utils as etau
 
 import fiftyone as fo
 import fiftyone.core.context as foc
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/core/validation.py
+++ b/fiftyone/core/validation.py
@@ -5,6 +5,7 @@ Validation utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import eta.core.utils as etau
 
 import fiftyone.core.media as fom

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -5,6 +5,7 @@ Video frame views.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import deepcopy
 import logging

--- a/fiftyone/factory/repos/__init__.py
+++ b/fiftyone/factory/repos/__init__.py
@@ -5,6 +5,7 @@ FiftyOne repository factory.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from fiftyone.factory.repos.delegated_operation_doc import (
     DelegatedOperationDocument,
 )

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -5,6 +5,7 @@ FiftyOne delegated operation repository document.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import copy
 from datetime import datetime
 import logging

--- a/fiftyone/internal/features/flags.py
+++ b/fiftyone/internal/features/flags.py
@@ -8,8 +8,5 @@ FiftyOne feature flags.
 
 from typing import Literal
 
-
-FeatureFlag = Literal[
-    "VFF_MULTIMODAL",
-]
+FeatureFlag = Literal["VFF_MULTIMODAL",]
 """Enumeration of active feature flags."""

--- a/fiftyone/internal/secrets/__init__.py
+++ b/fiftyone/internal/secrets/__init__.py
@@ -9,6 +9,5 @@ FiftyOne secrets.
 from .providers import *
 from .secret import *
 
-
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [k for k, v in globals().items() if not k.startswith("_")]

--- a/fiftyone/internal/secrets/providers/__init__.py
+++ b/fiftyone/internal/secrets/providers/__init__.py
@@ -9,6 +9,5 @@ FiftyOne secrets providers.
 from .iprovider import ISecretProvider
 from .local import EnvSecretProvider
 
-
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [k for k, v in globals().items() if not k.startswith("_")]

--- a/fiftyone/internal/secrets/providers/local.py
+++ b/fiftyone/internal/secrets/providers/local.py
@@ -5,6 +5,7 @@ FiftyOne env secrets provider
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import re
 
 from ..providers.iprovider import ISecretProvider

--- a/fiftyone/internal/secrets/secret.py
+++ b/fiftyone/internal/secrets/secret.py
@@ -68,13 +68,11 @@ class AbstractSecret(ISecret, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def key(self) -> str:
-        ...
+    def key(self) -> str: ...
 
     @property
     @abc.abstractmethod
-    def value(self) -> Union[str, int, bytes]:
-        ...
+    def value(self) -> Union[str, int, bytes]: ...
 
     @property
     @abc.abstractmethod

--- a/fiftyone/migrations/revisions/admin/v0_15_0.py
+++ b/fiftyone/migrations/revisions/admin/v0_15_0.py
@@ -5,8 +5,8 @@ FiftyOne v0.15.0 admin revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import logging
 
+import logging
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/migrations/revisions/admin/v0_15_1.py
+++ b/fiftyone/migrations/revisions/admin/v0_15_1.py
@@ -5,10 +5,10 @@ FiftyOne v0.15.1 admin revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import json
 import os
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/migrations/revisions/v0_11_2.py
+++ b/fiftyone/migrations/revisions/v0_11_2.py
@@ -5,8 +5,8 @@ FiftyOne v0.11.2 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import logging
 
+import logging
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/migrations/revisions/v0_19_0.py
+++ b/fiftyone/migrations/revisions/v0_19_0.py
@@ -5,12 +5,12 @@ FiftyOne v0.19.0 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from datetime import datetime
 import logging
 import string
 
 from bson import ObjectId
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/migrations/revisions/v0_20_0.py
+++ b/fiftyone/migrations/revisions/v0_20_0.py
@@ -5,9 +5,9 @@ FiftyOne v0.20.0 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from bson import json_util
 import gridfs
-
 
 _OLD_SKLEARN_CONFIG_CLS = "fiftyone.brain.similarity.SimilarityConfig"
 _OLD_SKLEARN_RESULTS_CLS = "fiftyone.brain.similarity.SimilarityResults"

--- a/fiftyone/migrations/revisions/v0_23_0.py
+++ b/fiftyone/migrations/revisions/v0_23_0.py
@@ -6,7 +6,6 @@ FiftyOne v0.23.0 revision.
 |
 """
 
-
 from bson import ObjectId
 
 

--- a/fiftyone/migrations/revisions/v0_6_2.py
+++ b/fiftyone/migrations/revisions/v0_6_2.py
@@ -5,6 +5,7 @@ FiftyOne v0.6.2 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import pymongo as pm
 
 

--- a/fiftyone/migrations/revisions/v0_7_2.py
+++ b/fiftyone/migrations/revisions/v0_7_2.py
@@ -5,6 +5,7 @@ FiftyOne v0.7.2 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import pymongo as pm
 
 

--- a/fiftyone/migrations/revisions/v1_0_0.py
+++ b/fiftyone/migrations/revisions/v1_0_0.py
@@ -5,6 +5,7 @@ FiftyOne v1.0.0 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from datetime import datetime
 
 

--- a/fiftyone/migrations/revisions/v1_4_0.py
+++ b/fiftyone/migrations/revisions/v1_4_0.py
@@ -2,8 +2,8 @@
 FiftyOne v1.4.0 revision.
 
 In previous versions we used the run_link field in delegated operations to
-store the path to the log file. This revision migrates the data from the 
-run_link field to the new log_path field allowing for the use of both fields 
+store the path to the log file. This revision migrates the data from the
+run_link field to the new log_path field allowing for the use of both fields
 and a cleaner implementation.
 
 | Copyright 2017-2026, Voxel51, Inc.

--- a/fiftyone/multimodal/__init__.py
+++ b/fiftyone/multimodal/__init__.py
@@ -30,7 +30,6 @@ from .media_reference import (
     WholeFile,
 )
 
-
 _LAZY_ATTRIBUTES = {
     "DecodedIngestFields": ("decoders", "DecodedIngestFields"),
     "DecodedIngestValue": ("decoders", "DecodedIngestValue"),

--- a/fiftyone/multimodal/decoders/__init__.py
+++ b/fiftyone/multimodal/decoders/__init__.py
@@ -20,7 +20,6 @@ from .registry import (
     register_decoder,
 )
 
-
 __all__ = [
     "DecodedIngestFields",
     "DecodedIngestValue",

--- a/fiftyone/multimodal/resolver/__init__.py
+++ b/fiftyone/multimodal/resolver/__init__.py
@@ -8,5 +8,4 @@ Resolver scaffolding for multimodal workflows.
 
 from .base import PlaybackPlanBuilder
 
-
 __all__ = ["PlaybackPlanBuilder"]

--- a/fiftyone/operators/__init__.py
+++ b/fiftyone/operators/__init__.py
@@ -5,6 +5,7 @@ FiftyOne operators.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from .operator import Operator, OperatorConfig, PipelineOperator
 from .registry import (
     OperatorRegistry,

--- a/fiftyone/operators/cache/__init__.py
+++ b/fiftyone/operators/cache/__init__.py
@@ -5,6 +5,7 @@ Execution cache.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .decorator import execution_cache

--- a/fiftyone/operators/cache/ephemeral.py
+++ b/fiftyone/operators/cache/ephemeral.py
@@ -5,12 +5,13 @@ Execution cache in memory.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from cachetools import LRUCache
 from threading import Lock
 
-
 _EPHEMERAL_CACHE_REGISTRY = {}
 _EPHEMERAL_CACHE_LOCK = Lock()
+
 
 def get_ephemeral_cache(func_id, max_size=None):
     max_size = max_size or 1024

--- a/fiftyone/operators/cache/utils.py
+++ b/fiftyone/operators/cache/utils.py
@@ -5,6 +5,7 @@ Execution cache utils.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from cachetools.keys import hashkey
 from dateutil import parser as dateparser
 import hashlib

--- a/fiftyone/operators/decorators.py
+++ b/fiftyone/operators/decorators.py
@@ -5,6 +5,7 @@ FiftyOne operator decorators.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import asyncio
 
 from cachetools.keys import hashkey

--- a/fiftyone/operators/permissions.py
+++ b/fiftyone/operators/permissions.py
@@ -5,6 +5,7 @@ FiftyOne operator permissions.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from .registry import OperatorRegistry
 
 

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -5,6 +5,7 @@ FiftyOne operator server.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import contextlib
 import types
 from sse_starlette.sse import EventSourceResponse

--- a/fiftyone/operators/store/__init__.py
+++ b/fiftyone/operators/store/__init__.py
@@ -5,6 +5,7 @@ Execution store.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .service import ExecutionStoreService

--- a/fiftyone/operators/store/transient_jobs.py
+++ b/fiftyone/operators/store/transient_jobs.py
@@ -9,7 +9,6 @@ import copy
 import datetime
 import uuid
 
-
 _IMMUTABLE_FIELDS = ("id", "owner", "scope", "payload", "created_at")
 _TERMINAL_STATES = {"completed", "failed", "canceled"}
 

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -5,6 +5,7 @@ FiftyOne operator types.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from ._types.pipeline import Pipeline, PipelineRunInfo, PipelineStage

--- a/fiftyone/plugins/__init__.py
+++ b/fiftyone/plugins/__init__.py
@@ -5,6 +5,7 @@ FiftyOne plugins.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .core import (

--- a/fiftyone/plugins/constants.py
+++ b/fiftyone/plugins/constants.py
@@ -5,6 +5,7 @@ FiftyOne plugins constants.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 
 BUILTIN_PLUGINS_DIR = os.path.normpath(

--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -21,7 +21,6 @@ import fiftyone.plugins as fop
 from fiftyone.operators.decorators import plugins_cache
 from fiftyone.operators.operator import Operator
 
-
 logger = logging.getLogger(__name__)
 
 INIT_FILENAME = "__init__.py"

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -5,6 +5,7 @@ Core plugin methods.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from dataclasses import dataclass
 import json
 import logging

--- a/fiftyone/plugins/secrets.py
+++ b/fiftyone/plugins/secrets.py
@@ -5,6 +5,7 @@ Plugin secrets resolver.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import traceback
 import typing

--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -5,6 +5,7 @@ FiftyOne plugin utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import multiprocessing.dummy
 import os
@@ -15,7 +16,6 @@ import yaml
 import fiftyone.core.utils as fou
 from fiftyone.utils.github import GitHubRepository
 from fiftyone.plugins.core import PLUGIN_METADATA_FILENAMES
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/server/aggregate.py
+++ b/fiftyone/server/aggregate.py
@@ -20,7 +20,6 @@ from fiftyone.server.data import T
 from fiftyone.server.scalars import BSONArray
 from fiftyone.server.view import load_view, ExtendedViewForm
 
-
 _DEFAULT_NUM_HISTOGRAM_BINS = 25
 
 

--- a/fiftyone/server/context.py
+++ b/fiftyone/server/context.py
@@ -5,6 +5,7 @@ FiftyOne Server context
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import typing as t
 
 import starlette.requests as strq

--- a/fiftyone/server/data.py
+++ b/fiftyone/server/data.py
@@ -5,6 +5,7 @@ FiftyOne Server data
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from dataclasses import dataclass
 import typing as t
 
@@ -13,7 +14,6 @@ import starlette.requests as strq
 import starlette.responses as strp
 import strawberry.types as gqlt
 from strawberry.dataloader import DataLoader
-
 
 T = t.TypeVar("T")
 

--- a/fiftyone/server/dataloader.py
+++ b/fiftyone/server/dataloader.py
@@ -5,6 +5,7 @@ FiftyOne Server dataloader
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from dataclasses import dataclass
 import typing as t
 
@@ -64,7 +65,10 @@ def get_dataloader_resolver(
     key: str,
     filters: t.List[dict],
     projections: t.Optional[t.Dict] = None,
-) -> t.Callable[[str, Info], t.Coroutine[t.Any, t.Any, t.Optional[T]],]:
+) -> t.Callable[
+    [str, Info],
+    t.Coroutine[t.Any, t.Any, t.Optional[T]],
+]:
     dataloaders[cls] = DataLoaderConfig(
         collection=collection,
         key=key,

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -20,7 +20,6 @@ from fiftyone.core.utils import create_response
 from fiftyone.server import utils
 from fiftyone.server.exceptions import DbVersionMismatchError
 
-
 _BODY_METHOD_NAMES = {"post", "put", "patch"}
 
 

--- a/fiftyone/server/events/polling.py
+++ b/fiftyone/server/events/polling.py
@@ -23,10 +23,9 @@ from fiftyone.core.session.events import (
 from fiftyone.server.events.initialize import initialize_listener
 from fiftyone.server.events.state import Listener, get_listeners, get_requests
 
-
-_polling_listener: t.Optional[
-    t.Tuple[str, t.Set[t.Tuple[str, Listener]]]
-] = None
+_polling_listener: t.Optional[t.Tuple[str, t.Set[t.Tuple[str, Listener]]]] = (
+    None
+)
 
 
 async def dispatch_polling_event_listener(

--- a/fiftyone/server/extensions.py
+++ b/fiftyone/server/extensions.py
@@ -5,6 +5,7 @@ FiftyOne Server extensions
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import traceback
 
 from graphql import GraphQLError

--- a/fiftyone/server/indexes.py
+++ b/fiftyone/server/indexes.py
@@ -13,7 +13,6 @@ import strawberry as gql
 
 from fiftyone.core.collections import SampleCollection
 
-
 _FRAMES_SLICE = len(SampleCollection._FRAMES_PREFIX)
 _WILDCARD_PROJECTION = "wildcardProjection"
 

--- a/fiftyone/server/inputs.py
+++ b/fiftyone/server/inputs.py
@@ -5,6 +5,7 @@ FiftyOne Server shared GraphQL input types.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import typing as t
 import strawberry as gql
 

--- a/fiftyone/server/interfaces.py
+++ b/fiftyone/server/interfaces.py
@@ -5,6 +5,7 @@ FiftyOne Server interfaces
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import typing as t
 
 import strawberry as gql

--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -27,7 +27,6 @@ from fiftyone.server.scalars import BSON, JSON
 from fiftyone.server.utils import meets_type
 from fiftyone.server.view import get_view
 
-
 _TWENTY_FOUR = 24
 
 
@@ -544,9 +543,7 @@ def _first(
                             "input": "$_id" if list_of_lists else f"${path}",
                             "initialValue": None,
                             "in": {
-                                "$min"
-                                if sort == 1
-                                else "$max": [
+                                "$min" if sort == 1 else "$max": [
                                     "$$value",
                                     "$$this",
                                 ]

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -87,7 +87,11 @@ async def get_metadata(
     filepath = sample["filepath"]
     metadata = sample.get("metadata", None)
 
-    (opm_field, detections_fields, additional_fields,) = (
+    (
+        opm_field,
+        detections_fields,
+        additional_fields,
+    ) = (
         additional_media_fields
         if additional_media_fields is not None
         else _get_additional_media_fields(collection)

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -39,7 +39,6 @@ from fiftyone.server.query import (
 from fiftyone.server.scalars import BSON, BSONArray, JSON
 from fiftyone.server.view import get_view
 
-
 _CONVERSION_STAGES = {
     fos.ToClips,
     fos.ToEvaluationPatches,

--- a/fiftyone/server/paginator.py
+++ b/fiftyone/server/paginator.py
@@ -94,7 +94,10 @@ async def get_items(
 
 def get_paginator_resolver(
     cls: t.Type[T], key: str, filters: t.List[dict], collection: str
-) -> t.Callable[[t.Optional[int], t.Optional[str], Info], Connection[T, str],]:
+) -> t.Callable[
+    [t.Optional[int], t.Optional[str], Info],
+    Connection[T, str],
+]:
     async def paginate(
         search: t.Optional[str],
         first: t.Optional[int] = LIST_LIMIT,

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -53,7 +53,6 @@ from fiftyone.server.exceptions import QueryTimeout
 from fiftyone.server.utils import from_dict
 from fiftyone.server.workspace import Workspace
 
-
 ID = gql.scalar(
     t.NewType("ID", str),
     serialize=lambda v: str(v),

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -5,6 +5,7 @@ FiftyOne Server ``/embeddings`` route.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import itertools
 import traceback

--- a/fiftyone/server/routes/fiftyone.py
+++ b/fiftyone/server/routes/fiftyone.py
@@ -5,6 +5,7 @@ FiftyOne Server /fiftyone route
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 

--- a/fiftyone/server/routes/plugins.py
+++ b/fiftyone/server/routes/plugins.py
@@ -5,6 +5,7 @@ FiftyOne Server ``/plugins`` route.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 

--- a/fiftyone/server/routes/sample.py
+++ b/fiftyone/server/routes/sample.py
@@ -567,9 +567,11 @@ class SampleField(HTTPEndpoint):
             field_id,
             sample_id,
             dataset_id,
-            f" (generated_dataset={generated_dataset_name})"
-            if generated_dataset_name
-            else "",
+            (
+                f" (generated_dataset={generated_dataset_name})"
+                if generated_dataset_name
+                else ""
+            ),
         )
 
         if_last_modified_at = get_if_last_modified_at(request)

--- a/fiftyone/server/routes/video_labels.py
+++ b/fiftyone/server/routes/video_labels.py
@@ -33,7 +33,6 @@ import fiftyone.core.view as fov
 from fiftyone.server.decorators import route
 import fiftyone.server.view as fosv
 
-
 # Synthetic instance-id prefix for an index-based track (a label with no
 # ``instance._id`` but a persisted ``index``). Must match the client's
 # ``TRACK_INDEX_PREFIX`` (``@fiftyone/annotation``) so the baseline index and

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -187,9 +187,11 @@ async def paginate_samples(
         # location; the rest are composed from where their source is
         node.sample["_media"] = {
             "assets": [
-                {**asset, "src": media_srcs[asset["id"]]}
-                if asset["id"] in media_srcs
-                else asset
+                (
+                    {**asset, "src": media_srcs[asset["id"]]}
+                    if asset["id"] in media_srcs
+                    else asset
+                )
                 for asset in media.assets
             ],
             "poster": media.poster_id,

--- a/fiftyone/server/scalars.py
+++ b/fiftyone/server/scalars.py
@@ -15,7 +15,6 @@ import typing as t
 from fiftyone.core.json import stringify
 from fiftyone.core.utils import datetime_to_timestamp, timestamp_to_datetime
 
-
 BSON = gql.scalar(
     t.NewType("BSON", object),
     serialize=lambda v: json.loads(json_util.dumps(v)),

--- a/fiftyone/server/stage_definitions.py
+++ b/fiftyone/server/stage_definitions.py
@@ -5,6 +5,7 @@ FiftyOne Server stage definitions
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import typing as t
 
 import strawberry as gql

--- a/fiftyone/server/stages.py
+++ b/fiftyone/server/stages.py
@@ -5,6 +5,7 @@ FiftyOne Server stage definitions
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import typing as t
 import strawberry as gql
 

--- a/fiftyone/server/utils/__init__.py
+++ b/fiftyone/server/utils/__init__.py
@@ -19,7 +19,6 @@ import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
 from fiftyone.server.utils import http, json
 
-
 _cache = cachetools.TTLCache(maxsize=10, ttl=900)  # ttl in seconds
 _dacite_config = Config(check_types=False)
 

--- a/fiftyone/server/utils/streaming.py
+++ b/fiftyone/server/utils/streaming.py
@@ -10,7 +10,6 @@ import queue
 import threading
 import time
 
-
 _END = object()
 
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -26,7 +26,6 @@ import fiftyone.core.view as fov
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
 from fiftyone.server.scalars import BSONArray, JSON
 
-
 _LABEL_TAGS = "_label_tags"
 _TEMPORAL_TAGS = "_temporal_tags"
 

--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -27,6 +27,7 @@ exited.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import argparse
 import collections
 import enum
@@ -41,7 +42,6 @@ import psutil
 
 os.environ["FIFTYONE_DISABLE_SERVICES"] = "1"
 from fiftyone.service.ipc import IPCServer
-
 
 lock = threading.Lock()
 

--- a/fiftyone/types/__init__.py
+++ b/fiftyone/types/__init__.py
@@ -5,6 +5,7 @@ FiftyOne types.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .dataset_types import *

--- a/fiftyone/utils/activitynet.py
+++ b/fiftyone/utils/activitynet.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from itertools import chain
 import logging
 import os
@@ -18,7 +19,6 @@ import eta.core.web as etaw
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 import fiftyone.utils.youtube as fouy
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -5,6 +5,7 @@ Annotation utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict, OrderedDict
 from copy import deepcopy
 import getpass
@@ -29,7 +30,6 @@ import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.eta as foue
 import fiftyone.utils.image as foui
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/aws.py
+++ b/fiftyone/utils/aws.py
@@ -5,6 +5,7 @@ Utilities for working with `Amazon Web Services <https://aws.amazon.com>`.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import multiprocessing.dummy
 import os
@@ -16,7 +17,6 @@ import botocore
 import eta.core.utils as etau
 
 import fiftyone.core.utils as fou
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import logging
 import os
@@ -19,7 +20,6 @@ import fiftyone.core.labels as fol
 import fiftyone.core.metadata as fom
 import fiftyone.core.storage as fos
 import fiftyone.utils.data as foud
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -5,6 +5,7 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import logging
 import os

--- a/fiftyone/utils/caltech.py
+++ b/fiftyone/utils/caltech.py
@@ -7,6 +7,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 import shutil
@@ -16,7 +17,6 @@ import eta.core.web as etaw
 
 import fiftyone.types as fot
 import fiftyone.utils.data as foud
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -20,7 +21,6 @@ import fiftyone.core.sample as fos
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 import fiftyone.types as fot
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/clip/__init__.py
+++ b/fiftyone/utils/clip/__init__.py
@@ -4,6 +4,7 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .zoo import TorchCLIPModelConfig, TorchCLIPModel

--- a/fiftyone/utils/clip/model.py
+++ b/fiftyone/utils/clip/model.py
@@ -5,6 +5,7 @@ CLIP model from https://github.com/openai/CLIP.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import OrderedDict
 from typing import Tuple, Union
 

--- a/fiftyone/utils/clip/tokenizer.py
+++ b/fiftyone/utils/clip/tokenizer.py
@@ -5,6 +5,7 @@ CLIP text tokenizer from https://github.com/openai/CLIP.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from functools import lru_cache
 import gzip
 import html

--- a/fiftyone/utils/clip/zoo.py
+++ b/fiftyone/utils/clip/zoo.py
@@ -5,6 +5,7 @@ CLIP model wrapper for the FiftyOne Model Zoo.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 from packaging.version import Version
@@ -23,7 +24,6 @@ import torch
 
 from .tokenizer import SimpleTokenizer
 from .model import build_model
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 import csv
 from datetime import datetime

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -5,6 +5,7 @@ CSV utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import csv
 import os
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import copy, deepcopy
 from datetime import datetime
@@ -42,7 +43,6 @@ import fiftyone.core.utils as fou
 import fiftyone.utils.annotations as foua
 import fiftyone.utils.data as foud
 import fiftyone.utils.video as fouv
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/data/__init__.py
+++ b/fiftyone/utils/data/__init__.py
@@ -5,6 +5,7 @@ Data utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .base import *

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -5,6 +5,7 @@ Data utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import logging
 import multiprocessing.dummy
@@ -21,7 +22,6 @@ import eta.core.video as etav
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.fields as fof
 import fiftyone.core.utils as fou
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/data/converters.py
+++ b/fiftyone/utils/data/converters.py
@@ -5,6 +5,7 @@ Dataset format conversion utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import inspect
 import logging
 import os
@@ -16,7 +17,6 @@ import fiftyone.types as fot
 
 from .exporters import build_dataset_exporter
 from .importers import build_dataset_importer
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -44,7 +44,6 @@ from .parsers import (
     ImageSampleParser,
 )
 
-
 fota = fou.lazy_import("fiftyone.core.tags")
 foma = fou.lazy_import("fiftyone.multimodal.media_reference.asset_planning")
 fmm = fou.lazy_import("fiftyone.multimodal.media_reference.field_model")
@@ -2042,9 +2041,9 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         self._metadata["name"] = sample_collection._dataset.name
         self._metadata["media_type"] = sample_collection.media_type
         if sample_collection.media_type == fomm.GROUP:
-            self._metadata[
-                "group_media_types"
-            ] = sample_collection.group_media_types
+            self._metadata["group_media_types"] = (
+                sample_collection.group_media_types
+            )
 
         schema = sample_collection._serialize_field_schema()
         self._metadata["sample_fields"] = schema
@@ -2078,27 +2077,27 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
             info["mask_targets"] = sample_collection._serialize_mask_targets()
 
         if sample_collection.default_mask_targets:
-            info[
-                "default_mask_targets"
-            ] = sample_collection._serialize_default_mask_targets()
+            info["default_mask_targets"] = (
+                sample_collection._serialize_default_mask_targets()
+            )
 
         if sample_collection.skeletons:
             info["skeletons"] = sample_collection._serialize_skeletons()
 
         if sample_collection.default_skeleton:
-            info[
-                "default_skeleton"
-            ] = sample_collection._serialize_default_skeleton()
+            info["default_skeleton"] = (
+                sample_collection._serialize_default_skeleton()
+            )
 
         if sample_collection.camera_intrinsics:
-            info[
-                "camera_intrinsics"
-            ] = sample_collection._serialize_camera_intrinsics()
+            info["camera_intrinsics"] = (
+                sample_collection._serialize_camera_intrinsics()
+            )
 
         if sample_collection.static_transforms:
-            info[
-                "static_transforms"
-            ] = sample_collection._serialize_static_transforms()
+            info["static_transforms"] = (
+                sample_collection._serialize_static_transforms()
+            )
 
         if sample_collection.app_config.is_custom():
             info["app_config"] = sample_collection.app_config.to_dict(

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -47,7 +47,6 @@ from .parsers import (
     FiftyOneVideoLabelsSampleParser,
 )
 
-
 fota = fou.lazy_import("fiftyone.core.tags")
 foma = fou.lazy_import("fiftyone.multimodal.media_reference.asset_planning")
 fmm = fou.lazy_import("fiftyone.multimodal.media_reference.field_model")

--- a/fiftyone/utils/data/ingestors.py
+++ b/fiftyone/utils/data/ingestors.py
@@ -5,6 +5,7 @@ Dataset ingestors.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 
 import eta.core.utils as etau
@@ -19,7 +20,6 @@ from .importers import (
     UnlabeledVideoDatasetImporter,
     LabeledVideoDatasetImporter,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -5,6 +5,7 @@ Sample parsers.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 
 import numpy as np

--- a/fiftyone/utils/dicom.py
+++ b/fiftyone/utils/dicom.py
@@ -21,7 +21,6 @@ fou.ensure_package("pydicom>=2.2.0")
 import pydicom
 from pydicom.fileset import FileInstance, FileSet
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/utils/eta.py
+++ b/fiftyone/utils/eta.py
@@ -6,6 +6,7 @@ Utilities for interfacing with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 import warnings
 
@@ -26,7 +27,6 @@ import eta.core.video as etav
 
 import fiftyone.core.labels as fol
 import fiftyone.core.models as fom
-
 
 _IMAGE_MODELS = (
     etal.ImageModel,

--- a/fiftyone/utils/eval/__init__.py
+++ b/fiftyone/utils/eval/__init__.py
@@ -5,6 +5,7 @@ Evaluation utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .base import get_subset_view

--- a/fiftyone/utils/eval/activitynet.py
+++ b/fiftyone/utils/eval/activitynet.py
@@ -5,6 +5,7 @@ ActivityNet-style temporal detection evaluation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 from collections import defaultdict
 
@@ -20,7 +21,6 @@ from .detection import (
     DetectionEvaluationConfig,
     DetectionResults,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -23,7 +23,6 @@ from .detection import (
     DetectionResults,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -27,7 +27,6 @@ from .base import (
     BaseClassificationResults,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -5,6 +5,7 @@ Open Images-style detection evaluation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import deepcopy
 

--- a/fiftyone/utils/eval/regression.py
+++ b/fiftyone/utils/eval/regression.py
@@ -29,7 +29,6 @@ from .base import (
     BaseEvaluationResults,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -5,6 +5,7 @@ Segmentation evaluation.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 import logging
 import inspect
@@ -28,7 +29,6 @@ from .base import (
     BaseEvaluationMethodConfig,
     BaseClassificationResults,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 from collections import defaultdict
@@ -20,7 +21,6 @@ import fiftyone.utils.data as foud
 
 from fiftyone.core.expressions import ViewField as F
 from fiftyone.core.expressions import VALUE
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/flash.py
+++ b/fiftyone/utils/flash.py
@@ -6,6 +6,7 @@ Utilities for working with
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import inspect
 import itertools
 
@@ -21,7 +22,6 @@ import flash.image as fi
 import flash.image.detection.output as fdo
 import flash.image.segmentation.output as fso
 import flash.video as fv
-
 
 _SUPPORTED_MODELS = (
     fi.ImageClassifier,

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -5,6 +5,7 @@ GeoJSON utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -18,7 +19,6 @@ import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.data as foud
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/geotiff.py
+++ b/fiftyone/utils/geotiff.py
@@ -5,6 +5,7 @@ GeoTIFF utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 
 import eta.core.image as etai

--- a/fiftyone/utils/github.py
+++ b/fiftyone/utils/github.py
@@ -5,6 +5,7 @@ GitHub utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 import re
@@ -12,7 +13,6 @@ import requests
 
 import eta.core.utils as etau
 import eta.core.web as etaw
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/groups.py
+++ b/fiftyone/utils/groups.py
@@ -5,6 +5,7 @@ Grouped dataset utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import fiftyone.core.dataset as fod
 import fiftyone.core.groups as fog
 

--- a/fiftyone/utils/hmdb51.py
+++ b/fiftyone/utils/hmdb51.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -13,7 +14,6 @@ import eta.core.utils as etau
 import eta.core.web as etaw
 
 import fiftyone.core.utils as fou
-
 
 logger = logging.getLogger(__name__)
 
@@ -78,13 +78,9 @@ def download_hmdb51_dataset(
         etau.delete_dir(scratch_dir)
 
 
-_VIDEOS_DOWNLOAD_LINK = (
-    "https://drive.usercontent.google.com/download?id=17anw5Oxp7lmp9cMwXPOyOpL5olDLmPpj&export=download&confirm=t"
-)
+_VIDEOS_DOWNLOAD_LINK = "https://drive.usercontent.google.com/download?id=17anw5Oxp7lmp9cMwXPOyOpL5olDLmPpj&export=download&confirm=t"
 
-_SPLITS_DOWNLOAD_LINK = (
-    "https://drive.usercontent.google.com/download?id=1NQxJWJSYWefyNS-LFYCenFih4gRDUPCX&export=download&confirm=t"
-)
+_SPLITS_DOWNLOAD_LINK = "https://drive.usercontent.google.com/download?id=1NQxJWJSYWefyNS-LFYCenFih4gRDUPCX&export=download&confirm=t"
 
 
 def _download_videos(scratch_dir):

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -5,6 +5,7 @@ Image utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -14,7 +15,6 @@ import eta.core.utils as etau
 import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/imagenet.py
+++ b/fiftyone/utils/imagenet.py
@@ -5,8 +5,8 @@ Utilities for working with the `ImageNet dataset <http://www.image-net.org>`_.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import os
 
+import os
 
 _TRAIN_IMAGES_TAR = "ILSVRC2012_img_train.tar"
 _VAL_IMAGES_DIR = "ILSVRC2012_img_val.tar"

--- a/fiftyone/utils/kinetics.py
+++ b/fiftyone/utils/kinetics.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 import itertools
 import logging
@@ -18,7 +19,6 @@ import eta.core.web as etaw
 
 import fiftyone.core.utils as fou
 import fiftyone.utils.youtube as fouy
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import csv
 import logging
 import struct

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -6,6 +6,7 @@ Utilities for working with annotations in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import copy, deepcopy
 import logging
 import os

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -5,6 +5,7 @@ Label utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import eta.core.utils as etau
 from typing import Any, Callable, Dict, List, Optional
 import logging

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -6,6 +6,7 @@ Utilities for working with annotations in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from copy import deepcopy
 from datetime import datetime
 from collections import defaultdict

--- a/fiftyone/utils/lfw.py
+++ b/fiftyone/utils/lfw.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -13,7 +14,6 @@ import eta.core.utils as etau
 import eta.core.web as etaw
 
 import fiftyone.core.utils as fou
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/open_clip.py
+++ b/fiftyone/utils/open_clip.py
@@ -5,6 +5,7 @@ CLIP model wrapper for the FiftyOne Model Zoo.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import contextlib
 import logging
 

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -7,6 +7,7 @@ dataset.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 import csv
 from glob import glob
@@ -28,7 +29,6 @@ import fiftyone.core.labels as fol
 import fiftyone.utils.aws as foua
 import fiftyone.utils.data as foud
 import fiftyone.utils.image as foui
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/openlabel.py
+++ b/fiftyone/utils/openlabel.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import deepcopy
 import enum
@@ -19,7 +20,6 @@ import fiftyone.core.labels as fol
 import fiftyone.core.metadata as fom
 import fiftyone.core.storage as fos
 import fiftyone.utils.data as foud
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -5,6 +5,7 @@ Image patch utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import cv2
 
 import fiftyone.core.frame as fof

--- a/fiftyone/utils/pe.py
+++ b/fiftyone/utils/pe.py
@@ -1,5 +1,5 @@
-"""FiftyOne Integration with Perception Encoder by Meta.
-"""
+"""FiftyOne Integration with Perception Encoder by Meta."""
+
 import fiftyone as fo
 import fiftyone.core.models as fom
 import fiftyone.core.utils as fou

--- a/fiftyone/utils/places.py
+++ b/fiftyone/utils/places.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import logging
 import shutil

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -5,6 +5,7 @@ FiftyOne quickstart.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import fiftyone as fo
 import fiftyone.core.context as focx
 import fiftyone.core.session as fos

--- a/fiftyone/utils/random.py
+++ b/fiftyone/utils/random.py
@@ -5,6 +5,7 @@ Random sampling utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import numpy as np
 
 

--- a/fiftyone/utils/rfdetr.py
+++ b/fiftyone/utils/rfdetr.py
@@ -91,9 +91,7 @@ def _normalize_rfdetr_device(device):
     return device
 
 
-def _load_rfdetr_model(
-    model_type: str, device: Optional[str] = None
-) -> Any:
+def _load_rfdetr_model(model_type: str, device: Optional[str] = None) -> Any:
     """Instantiate an RF-DETR model by class name.
 
     The rfdetr package downloads pretrained weights automatically on first
@@ -197,9 +195,7 @@ def _make_frame_detection(
             (x2 - x1) / width,
             (y2 - y1) / height,
         ],
-        "confidence": (
-            float(confidence) if confidence is not None else None
-        ),
+        "confidence": (float(confidence) if confidence is not None else None),
     }
 
     if mask is not None:

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -971,9 +971,9 @@ class SegmentAnythingModel(fout.TorchImageModelWithPrompts):
                 [img_hw],
                 confidence_thresh=self.config.confidence_thresh,
                 box_prompts=[boxes_xyxy] if boxes_xyxy is not None else None,
-                labels=[prompt_classes]
-                if prompt_classes is not None
-                else None,
+                labels=(
+                    [prompt_classes] if prompt_classes is not None else None
+                ),
                 mask_index=self.config.points_mask_index,
             )[0]
         return output
@@ -1203,9 +1203,9 @@ class SegmentAnythingModel(fout.TorchImageModelWithPrompts):
             sparse_embeddings, dense_embeddings = self._model.prompt_encoder(
                 points=points,
                 boxes=boxes[img_idx] if boxes is not None else None,
-                masks=mask_inputs[img_idx]
-                if mask_inputs is not None
-                else None,
+                masks=(
+                    mask_inputs[img_idx] if mask_inputs is not None else None
+                ),
             )
 
             low_res_masks, iou_predictions = self._model.mask_decoder(

--- a/fiftyone/utils/sam2.py
+++ b/fiftyone/utils/sam2.py
@@ -387,12 +387,12 @@ class SegmentAnything2ImageModel(fosam.SegmentAnythingModel):
         outputs = []
         for img_idx in range(len(images)):
             out_masks, iou_pred, _ = self._sam_predictor.processor._predict(
-                point_coords=point_coords[img_idx]
-                if point_coords is not None
-                else None,
-                point_labels=point_labels[img_idx]
-                if point_labels is not None
-                else None,
+                point_coords=(
+                    point_coords[img_idx] if point_coords is not None else None
+                ),
+                point_labels=(
+                    point_labels[img_idx] if point_labels is not None else None
+                ),
                 boxes=boxes[img_idx] if boxes is not None else None,
                 mask_input=mask_inputs[img_idx] if mask_inputs else None,
                 multimask_output=multimask_output,

--- a/fiftyone/utils/sam3.py
+++ b/fiftyone/utils/sam3.py
@@ -989,7 +989,8 @@ class SegmentAnything3VideoModel(fom.SamplesMixin, fom.Model):
     def _get_frame_indices(self):
         """Return the frame indices from which to extract prompt fields for prompting.
 
-        When ``None``,``prompt_field`` in all the frames are used for visual prompting."""
+        When ``None``,``prompt_field`` in all the frames are used for visual prompting.
+        """
 
         prompt_frame_indices = self.config.prompt_frame_indices
         if prompt_frame_indices is None:

--- a/fiftyone/utils/sama.py
+++ b/fiftyone/utils/sama.py
@@ -5,6 +5,7 @@ Sama utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import glob
 import random

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -6,6 +6,7 @@ Utilities for working with annotations in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import deepcopy
 import logging
@@ -27,7 +28,6 @@ import fiftyone.core.metadata as fom
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.image as foui
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/super_gradients.py
+++ b/fiftyone/utils/super_gradients.py
@@ -6,6 +6,7 @@ Utilities for working with
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 from urllib.parse import urlparse

--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -5,6 +5,7 @@ TensorFlow utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import contextlib
 import logging
 import multiprocessing
@@ -26,7 +27,6 @@ import fiftyone.utils.data as foud
 
 fou.ensure_tf(eager=True)
 import tensorflow as tf
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -42,7 +42,6 @@ import torchvision
 from torchvision.models.feature_extraction import create_feature_extractor
 from torchvision.transforms import functional as F
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/utils/tracking/__init__.py
+++ b/fiftyone/utils/tracking/__init__.py
@@ -5,6 +5,7 @@ Tracking utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 
 from .deepsort import *

--- a/fiftyone/utils/tracking/deepsort.py
+++ b/fiftyone/utils/tracking/deepsort.py
@@ -5,6 +5,7 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 
 import eta.core.video as etav

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -21,14 +21,11 @@ from fiftyone.core.models import EmbeddingsMixin, PromptMixin
 from fiftyone.zoo.models import HasZooModel
 import fiftyone.utils.torch as fout
 
-
 fou.ensure_torch()
 import torch
 
-
 fou.ensure_package("transformers")
 import transformers
-
 
 logger = logging.getLogger(__name__)
 
@@ -674,9 +671,9 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, fout.TorchImageModel):
         if config.entrypoint_args is None:
             config.entrypoint_args = {}
         if not config.entrypoint_args.get("pretrained_model_name_or_path"):
-            config.entrypoint_args[
-                "pretrained_model_name_or_path"
-            ] = config.name_or_path
+            config.entrypoint_args["pretrained_model_name_or_path"] = (
+                config.name_or_path
+            )
 
         config.entrypoint_args["cache_dir"] = fo.config.model_zoo_dir
 
@@ -1657,9 +1654,11 @@ class _HFTransformsHandler:
             elif self.text:
                 res = self.processor(
                     images=args,
-                    text=self.text
-                    if not self.text_per_image
-                    else [self.text for _ in range(num_images)],
+                    text=(
+                        self.text
+                        if not self.text_per_image
+                        else [self.text for _ in range(num_images)]
+                    ),
                     **self.kwargs,
                 )
             else:

--- a/fiftyone/utils/transforms.py
+++ b/fiftyone/utils/transforms.py
@@ -26,7 +26,6 @@ see :mod:`fiftyone.core.camera`.
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-
 # =============================================================================
 # Coordinate System Constants
 # =============================================================================

--- a/fiftyone/utils/ucf101.py
+++ b/fiftyone/utils/ucf101.py
@@ -6,6 +6,7 @@ Utilities for working with the
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -13,7 +14,6 @@ import eta.core.utils as etau
 import eta.core.web as etaw
 
 import fiftyone.core.utils as fou
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -19,7 +19,6 @@ import fiftyone.utils.torch as fout
 import fiftyone.core.utils as fou
 import fiftyone.zoo.models as fozm
 
-
 ultralytics = fou.lazy_import("ultralytics")
 torch = fou.lazy_import("torch")
 torchvision = fou.lazy_import("torchvision")
@@ -662,9 +661,9 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
     def _build_output_processor(self, config):
         if not config.output_processor_args:
             config.output_processor_args = {}
-        config.output_processor_args[
-            "post_processor"
-        ] = self._model.predictor.postprocess
+        config.output_processor_args["post_processor"] = (
+            self._model.predictor.postprocess
+        )
         output_processor = super()._build_output_processor(config)
         # Set post-processor to None for config JSON serialization.
         config.output_processor_args["post_processor"] = None
@@ -705,6 +704,7 @@ class FiftyOneYOLOModel(fout.TorchImageModel):
             confidence_thresh=self.config.confidence_thresh,
             classes=self.config.filter_classes,
         )
+
 
 class YOLOEVPGetItem(fout.GetItem):
     """A :class:`GetItem` that loads images and box prompt detections for
@@ -891,9 +891,11 @@ class FiftyOneYOLOEVPModel(FiftyOneYOLOModel):
                     mode="predict",
                     verbose=False,
                     device=self._device,
-                    conf=self.config.confidence_thresh
-                    if self.config.confidence_thresh is not None
-                    else default_conf,
+                    conf=(
+                        self.config.confidence_thresh
+                        if self.config.confidence_thresh is not None
+                        else default_conf
+                    ),
                 )
             )
 

--- a/fiftyone/utils/useragent.py
+++ b/fiftyone/utils/useragent.py
@@ -5,6 +5,7 @@ User agent utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import fiftyone.constants as foc
 
 

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -5,6 +5,7 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import contextlib
 import functools
 import logging
@@ -596,9 +597,9 @@ def pinhole_projector(
         raise ValueError("points must be a 3xN array")
 
     cam_int_pad = np.eye(4)
-    cam_int_pad[
-        : camera_intrinsics.shape[0], : camera_intrinsics.shape[1]
-    ] = camera_intrinsics
+    cam_int_pad[: camera_intrinsics.shape[0], : camera_intrinsics.shape[1]] = (
+        camera_intrinsics
+    )
     nbr_points = points.shape[1]
 
     points = np.concatenate((points, np.ones((1, nbr_points))))

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -5,6 +5,7 @@ Video utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import json
 import logging
@@ -21,7 +22,6 @@ import fiftyone.core.metadata as fom
 import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
-
 
 logger = logging.getLogger(__name__)
 
@@ -906,7 +906,9 @@ def _transform_video(
             # so players can start playback without seeking to the end.
             kwargs["in_opts"] = None
             if out_ext.lower() in (".mp4", ".mov", ".m4v"):
-                kwargs["out_opts"] = list(etav.FFmpeg.DEFAULT_VIDEO_OUT_OPTS) + [
+                kwargs["out_opts"] = list(
+                    etav.FFmpeg.DEFAULT_VIDEO_OUT_OPTS
+                ) + [
                     "-movflags",
                     "+faststart",
                 ]

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -19,7 +20,6 @@ import fiftyone.core.metadata as fom
 import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
-
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -23,7 +23,6 @@ import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/fiftyone/utils/youtube.py
+++ b/fiftyone/utils/youtube.py
@@ -5,6 +5,7 @@ Utilities for working with `YouTube <https://youtube.com>`.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import itertools
 import logging
 import multiprocessing.dummy

--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -4,6 +4,7 @@ The FiftyOne Zoo.
 Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
+
 import types
 
 from .datasets import *

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -27,7 +27,6 @@ import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 from fiftyone.utils.github import GitHubRepository
 
-
 DATASET_METADATA_FILENAMES = ("fiftyone.yml", "fiftyone.yaml")
 
 logger = logging.getLogger(__name__)

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -5,6 +5,7 @@ FiftyOne Zoo Datasets provided natively by the library.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 import shutil

--- a/fiftyone/zoo/datasets/tf.py
+++ b/fiftyone/zoo/datasets/tf.py
@@ -5,13 +5,13 @@ FiftyOne Zoo Datasets provided by ``tensorflow_datasets``.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 import fiftyone.types as fot
 import fiftyone.utils.imagenet as foui
 import fiftyone.utils.data as foud
 import fiftyone.zoo.datasets as fozd
-
 
 _TFDS_IMPORT_ERROR = """
 

--- a/fiftyone/zoo/datasets/torch.py
+++ b/fiftyone/zoo/datasets/torch.py
@@ -5,6 +5,7 @@ FiftyOne Zoo Datasets provided by :mod:`torchvision:torchvision.datasets`.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import eta.core.utils as etau
 
 import fiftyone.core.labels as fol
@@ -15,7 +16,6 @@ import fiftyone.utils.data as foud
 import fiftyone.utils.imagenet as foui
 import fiftyone.utils.voc as fouv
 import fiftyone.zoo.datasets as fozd
-
 
 _TORCH_IMPORT_ERROR = """
 

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -5,6 +5,7 @@ The FiftyOne Model Zoo.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from copy import deepcopy
 import functools
@@ -24,7 +25,6 @@ import fiftyone as fo
 import fiftyone.core.models as fom
 import fiftyone.core.utils as fou
 from fiftyone.utils.github import GitHubRepository
-
 
 MODELS_MANIEST_FILENAME = "manifest.json"
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/fiftyone/zoo/models/torch.py
+++ b/fiftyone/zoo/models/torch.py
@@ -5,6 +5,7 @@ FiftyOne Zoo models provided by :mod:`torchvision:torchvision.models`.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import contextlib
 import inspect
 import logging
@@ -17,7 +18,6 @@ import fiftyone.zoo.models as fozm
 
 fou.ensure_torch()
 import torchvision
-
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/operators/annotation.py
+++ b/plugins/operators/annotation.py
@@ -20,7 +20,6 @@ import fiftyone.core.fields as fof
 import fiftyone.operators as foo
 import fiftyone.operators.types as types
 
-
 _FRAMES_PREFIX = "frames."
 
 

--- a/plugins/operators/model_evaluation/utils.py
+++ b/plugins/operators/model_evaluation/utils.py
@@ -64,8 +64,7 @@ def get_scenario_example(
     reason=ScenarioType.CUSTOM_CODE, type=ScenarioType.CUSTOM_CODE, field=None
 ):
     examples = {
-        ScenarioType.CUSTOM_CODE: dedent(
-            """
+        ScenarioType.CUSTOM_CODE: dedent("""
             from fiftyone import ViewField as F
 
             bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
@@ -74,10 +73,8 @@ def get_scenario_example(
                 "Medium objects": dict(type="attribute", expr=(0.05 <= bbox_area) & (bbox_area <= 0.5)),
                 "Large objects": dict(type="attribute", expr=bbox_area > 0.5),
             }
-        """
-        ).strip(),
-        CustomCodeViewReason.FLOAT_TYPE: dedent(
-            """
+        """).strip(),
+        CustomCodeViewReason.FLOAT_TYPE: dedent("""
             from fiftyone import ViewField as F
 
             subsets = {
@@ -88,10 +85,8 @@ def get_scenario_example(
                     dict(type="field", expr=F("uniqueness") < 0.165),
                 ]
             }
-            """
-        ).strip(),
-        CustomCodeViewReason.TOO_MANY_CATEGORIES: dedent(
-            """
+            """).strip(),
+        CustomCodeViewReason.TOO_MANY_CATEGORIES: dedent("""
             from fiftyone import ViewField as F
             bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
             subsets = {
@@ -99,17 +94,14 @@ def get_scenario_example(
                 "Medium objects": dict(type="attribute", expr=(0.05 <= bbox_area) & (bbox_area <= 0.5)),
                 "Large objects": dict(type="attribute", expr=bbox_area > 0.5),
             }
-            """
-        ).strip(),
-        CustomCodeViewReason.TOO_MANY_INT_CATEGORIES: dedent(
-            """
+            """).strip(),
+        CustomCodeViewReason.TOO_MANY_INT_CATEGORIES: dedent("""
             from fiftyone import ViewField as F
             subsets = {
                 "few ints": dict(type="field", expr=F("int_field") > 100),
                 "many ints": dict(type="field", expr=F("int_field") <= 100),
             }
-            """
-        ).strip(),
+            """).strip(),
     }
     example = examples.get(reason, "")
 
@@ -121,16 +113,14 @@ def get_scenario_example(
     is_sample_field = type == ScenarioType.SAMPLE_FIELD
     is_label_attribute = type == ScenarioType.LABEL_ATTRIBUTE
     if (is_sample_field or is_label_attribute) and is_numeric:
-        example = dedent(
-            """
+        example = dedent("""
             from fiftyone import ViewField as F
 
             subsets = {
                 "subset 1": dict(type="$TYPE", expr=F("$FIELD") < 0.25),
                 "subset 2": dict(type="$TYPE", expr=F("$FIELD") > 0.75),
             }
-            """
-        ).strip()
+            """).strip()
         if is_label_attribute and field:
             example = example.replace("$FIELD", field)
             example = example.replace("$TYPE", "attribute")

--- a/plugins/panels/model_evaluation/__init__.py
+++ b/plugins/panels/model_evaluation/__init__.py
@@ -565,9 +565,9 @@ class EvaluationPanel(Panel):
                     }
                 )
         if update_store:
-            pending_evaluations_in_store[
-                dataset_id
-            ] = updated_pending_evaluations_for_dataset_in_stored
+            pending_evaluations_in_store[dataset_id] = (
+                updated_pending_evaluations_for_dataset_in_stored
+            )
             store.set("pending_evaluations", pending_evaluations_in_store)
         ctx.panel.set_data("pending_evaluations", pending_evaluations)
 

--- a/plugins/utils/model_evaluation/__init__.py
+++ b/plugins/utils/model_evaluation/__init__.py
@@ -9,7 +9,6 @@ FiftyOne builtin plugins.
 from fiftyone.operators.store import ExecutionStore
 from bson import ObjectId
 
-
 STORE_NAME = "model_evaluation_panel_builtin"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,12 @@ exclude = '''
   | \.git
 )/
 '''
+extend-exclude = '''
+/(
+  docs/theme
+  | __generated__
+)/
+'''
 [tool.isort]
 profile = "black"
 line_length = 79

--- a/tests/benchmarking/add_samples_benchmark.py
+++ b/tests/benchmarking/add_samples_benchmark.py
@@ -7,6 +7,7 @@ Results are written to `add_samples_benchmark.log`.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -14,7 +15,6 @@ import eta.core.logging as etal
 
 import fiftyone as fo
 import fiftyone.zoo as foz
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/benchmarking/cifar10_benchmark.py
+++ b/tests/benchmarking/cifar10_benchmark.py
@@ -7,6 +7,7 @@ Results are appended to `cifar10_benchmark.log`.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import OrderedDict
 import pathlib
 import random

--- a/tests/intensive/collections_tests.py
+++ b/tests/intensive/collections_tests.py
@@ -9,13 +9,13 @@ All of these tests are designed to be run manually via::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import random
 import unittest
 
 import fiftyone as fo
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
-
 
 _ANIMALS = [
     "bear",

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from bson import ObjectId
 from collections import defaultdict
 import numpy as np

--- a/tests/intensive/dataset_zoo_tests.py
+++ b/tests/intensive/dataset_zoo_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import fiftyone as fo

--- a/tests/intensive/evaluation_tests.py
+++ b/tests/intensive/evaluation_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import random
 import unittest
 
@@ -20,7 +21,6 @@ import pytest
 import fiftyone as fo
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
-
 
 _ANIMALS = [
     "bear",

--- a/tests/intensive/import_export_tests.py
+++ b/tests/intensive/import_export_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import random
 import os
 

--- a/tests/intensive/labelbox_tests.py
+++ b/tests/intensive/labelbox_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 from uuid import uuid4
 
@@ -18,7 +19,6 @@ import eta.core.web as etaw
 import fiftyone as fo
 import fiftyone.zoo as foz
 import fiftyone.utils.labelbox as foul
-
 
 _anno_key = "anno_key"
 

--- a/tests/intensive/labelstudio_tests.py
+++ b/tests/intensive/labelstudio_tests.py
@@ -6,6 +6,7 @@ Tests for the :mod:`fiftyone.utils.labelstudio` module.
 |
 =======
 """
+
 import os
 import random
 

--- a/tests/intensive/lightning_flash_tests.py
+++ b/tests/intensive/lightning_flash_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import numpy as np
 import unittest
 from itertools import chain

--- a/tests/intensive/merge_tests.py
+++ b/tests/intensive/merge_tests.py
@@ -9,6 +9,7 @@ All of these tests are designed to be run manually via::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 
 import pytest

--- a/tests/intensive/model_tests.py
+++ b/tests/intensive/model_tests.py
@@ -9,6 +9,7 @@ All of these tests are designed to be run manually via::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import numpy as np

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -17,7 +17,6 @@ import fiftyone as fo
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
 
-
 _SAM_PROMPT_FIELD = "prompt_field"
 _APP_PORT = 5151
 

--- a/tests/intensive/patches_tests.py
+++ b/tests/intensive/patches_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import fiftyone as fo

--- a/tests/intensive/plot_tests.py
+++ b/tests/intensive/plot_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import random
 import unittest
 
@@ -18,7 +19,6 @@ import fiftyone as fo
 import fiftyone.brain as fob  # pylint: disable=import-error,no-name-in-module
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
-
 
 ###############################################################################
 # scatterplot()

--- a/tests/intensive/sam_image_model_tests.py
+++ b/tests/intensive/sam_image_model_tests.py
@@ -19,7 +19,6 @@ import fiftyone as fo
 import fiftyone.zoo as foz
 from fiftyone.core.labels import Detections
 
-
 PLACEHOLDER_LABEL = "mask"
 SAM_MODEL_NAME = "segment-anything-vitb-torch"
 SAM2_MODEL_NAME = "segment-anything-2-hiera-tiny-image-torch"

--- a/tests/intensive/sam_parity_tests.py
+++ b/tests/intensive/sam_parity_tests.py
@@ -2212,7 +2212,8 @@ class TestSAM3VideoVisualParity(unittest.TestCase):
         self, sample, propagation_direction, prompt_frame_0based
     ):
         """Run visual_predictor directly with box prompts from ``prompt_frame_0based``
-        using the specified propagation direction, mirroring FO's _propagate_visual."""
+        using the specified propagation direction, mirroring FO's _propagate_visual.
+        """
         w = sample.metadata.frame_width
         h = sample.metadata.frame_height
 

--- a/tests/intensive/scale_tests.py
+++ b/tests/intensive/scale_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import eta.core.utils as etau

--- a/tests/intensive/session_tests.py
+++ b/tests/intensive/session_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import fiftyone as fo

--- a/tests/intensive/utils_tests.py
+++ b/tests/intensive/utils_tests.py
@@ -5,6 +5,7 @@ Utils tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 
 import numpy as np

--- a/tests/intensive/video_tests.py
+++ b/tests/intensive/video_tests.py
@@ -9,6 +9,7 @@ You must run these tests interactively as follows::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import random
 import unittest
 

--- a/tests/intensive/view_tests.py
+++ b/tests/intensive/view_tests.py
@@ -9,6 +9,7 @@ All of these tests are designed to be run manually via::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import fiftyone as fo

--- a/tests/isolated/import_time_test.py
+++ b/tests/isolated/import_time_test.py
@@ -5,9 +5,9 @@ Test that fiftyone can be imported in a reasonable amount of time.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import warnings
 import time
-
 
 # TODO: decrease these once the DB service is started on-demand?
 IMPORT_WARN_THRESHOLD = 3

--- a/tests/isolated/service_tests.py
+++ b/tests/isolated/service_tests.py
@@ -5,6 +5,7 @@ Service tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from contextlib import contextmanager
 import os
 import sys
@@ -22,7 +23,6 @@ import fiftyone as fo
 import fiftyone.constants as foc
 import fiftyone.core.service as fos
 import fiftyone.service.util as fosu
-
 
 MONGOD_EXE_NAME = fos.DatabaseService.MONGOD_EXE_NAME
 

--- a/tests/misc/selection_tests.py
+++ b/tests/misc/selection_tests.py
@@ -6,6 +6,7 @@ Unit tests for :class:`fiftyone.core.stages.SelectObjects` and
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import random
 import unittest
 

--- a/tests/misc/torch_tests.py
+++ b/tests/misc/torch_tests.py
@@ -5,6 +5,7 @@ Tests for the :mod:`fiftyone.utils.torch` module.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import numpy as np

--- a/tests/no_wrapper/multiprocess_tests.py
+++ b/tests/no_wrapper/multiprocess_tests.py
@@ -5,6 +5,7 @@ Multiprocess tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import multiprocessing
 import os
 import unittest

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -5,6 +5,7 @@ Tests related to Session behavior.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import gc
 import time
 from unittest.mock import MagicMock, patch

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -5,6 +5,7 @@ FiftyOne aggregation-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from datetime import date, datetime, timedelta
 import math
 

--- a/tests/unittests/cpu_count_tests.py
+++ b/tests/unittests/cpu_count_tests.py
@@ -5,6 +5,7 @@ FiftyOne CPU count utility unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 from unittest.mock import patch, mock_open
 

--- a/tests/unittests/documents.py
+++ b/tests/unittests/documents.py
@@ -9,6 +9,7 @@ To run the unit tests, use the following command:
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 from mongoengine import EmbeddedDocument

--- a/tests/unittests/evaluation_plugins/__init__.py
+++ b/tests/unittests/evaluation_plugins/__init__.py
@@ -5,6 +5,7 @@ Evaluation tests operators.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import fiftyone as fo
 import fiftyone.operators as foo
 from fiftyone.operators import types

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -2066,7 +2066,9 @@ class DetectionsTests(unittest.TestCase):
         # overlap, so its mask IoU is 0 rather than a ZeroDivisionError
         mask = np.ones((10, 10), dtype=bool)
         gts = [fo.Detection(label="x", bounding_box=[0, 0, 0, 0.5], mask=mask)]
-        preds = [fo.Detection(label="x", bounding_box=[0, 0, 0.5, 0.5], mask=mask)]
+        preds = [
+            fo.Detection(label="x", bounding_box=[0, 0, 0.5, 0.5], mask=mask)
+        ]
 
         ious = foui.compute_ious(preds, gts, use_masks=True)
 

--- a/tests/unittests/execution_cache/decorator_tests.py
+++ b/tests/unittests/execution_cache/decorator_tests.py
@@ -5,6 +5,7 @@ Unit tests for fiftyone.operators.cache decorators.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +17,7 @@ from fiftyone.operators.cache.utils import (
 )
 from fiftyone.operators.cache.serialization import auto_serialize
 from fiftyone.operators.executor import ExecutionContext
+
 
 # Mock Execution Context with dataset
 def create_mock_ctx():

--- a/tests/unittests/execution_cache/decorators.py
+++ b/tests/unittests/execution_cache/decorators.py
@@ -5,6 +5,7 @@ Decorator utils for unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from functools import wraps
 import platform
 import unittest

--- a/tests/unittests/execution_cache/execution_cache_io_tests.py
+++ b/tests/unittests/execution_cache/execution_cache_io_tests.py
@@ -5,6 +5,7 @@ Integration tests for execution_cache.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 import fiftyone as fo
 
@@ -15,6 +16,7 @@ from fiftyone.operators.cache.utils import _build_cache_key
 from decorators import drop_datasets, drop_collection
 
 TEST_COLLECTION_NAME = "test-execution-cache"
+
 
 # Cached function that queries the dataset
 @execution_cache(ttl=60, collection_name=TEST_COLLECTION_NAME)

--- a/tests/unittests/execution_store_repo_tests.py
+++ b/tests/unittests/execution_store_repo_tests.py
@@ -109,6 +109,7 @@ class TestInMemoryExecutionStoreRepo(unittest.TestCase):
         explicit = self.repo.get_key(store_name, key)
         self.assertEqual(explicit.expires_at, expires_at)
         self.assertEqual(explicit.policy, KeyPolicy.PERSIST)
+
     def test_update_ttl(self):
         store_name = "ttl_store"
         key = "ttl_key"

--- a/tests/unittests/execution_store_unit_tests.py
+++ b/tests/unittests/execution_store_unit_tests.py
@@ -20,7 +20,6 @@ from fiftyone.operators.store.models import KeyDocument
 from fiftyone.factory.repo_factory import MongoExecutionStoreRepo
 from fiftyone.operators.store import ExecutionStore
 
-
 EPSILON = 0.1
 
 

--- a/tests/unittests/factory/delegated_operation_doc_tests.py
+++ b/tests/unittests/factory/delegated_operation_doc_tests.py
@@ -4,6 +4,7 @@ Unit tests for delegated ops doc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import pytest
 
 

--- a/tests/unittests/fcv_tests.py
+++ b/tests/unittests/fcv_tests.py
@@ -66,7 +66,7 @@ class TestUpdateFCV(unittest.TestCase):
                     Version(f"{server_version.major}.0")
                 )
                 mock_admin.command.assert_any_call(expected_call)
-                
+
                 mock_logger.warning.assert_any_call(
                     "Your MongoDB server version is newer than your feature "
                     "compatibility version. "

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -5,6 +5,7 @@ FiftyOne Label-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import tempfile
 import unittest
@@ -947,8 +948,10 @@ class ExportMaskTests(unittest.TestCase):
             with self.subTest(case["id"]):
                 with tempfile.TemporaryDirectory() as tmp:
                     src = os.path.join(tmp, "original.png")
-                    dst = src if case["overwrite_path"] else os.path.join(
-                        tmp, "copy.png"
+                    dst = (
+                        src
+                        if case["overwrite_path"]
+                        else os.path.join(tmp, "copy.png")
                     )
                     _write_mask(self._ZEROS, src)
 
@@ -1001,9 +1004,7 @@ class ExportMaskTests(unittest.TestCase):
                         _write_mask(self._ZEROS, mp)
                         outpath = mp
 
-                    det = self._make_detection(
-                        mask=case["mask"], mask_path=mp
-                    )
+                    det = self._make_detection(mask=case["mask"], mask_path=mp)
                     with self.assertRaises(ValueError, msg=case["id"]):
                         det.export_mask(
                             outpath, overwrite_path=case["overwrite_path"]

--- a/tests/unittests/map/test_implementations.py
+++ b/tests/unittests/map/test_implementations.py
@@ -12,7 +12,6 @@ import pytest
 import fiftyone as fo
 import fiftyone.core.map as fomm
 
-
 INPUT_KEY = "input"
 OUTPUT_KEY = "output"
 WORKERS = 8

--- a/tests/unittests/map/test_mapper.py
+++ b/tests/unittests/map/test_mapper.py
@@ -79,11 +79,9 @@ class Mapper(fomm.LocalMapper):
     """Test implementation for abstract class"""
 
     @classmethod
-    def create(cls, *_, **__):
-        ...
+    def create(cls, *_, **__): ...
 
-    def _map_samples_multiple_workers(self, *_, **__):
-        ...
+    def _map_samples_multiple_workers(self, *_, **__): ...
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/memory_limit_tests.py
+++ b/tests/unittests/memory_limit_tests.py
@@ -5,12 +5,12 @@ FiftyOne memory limit utility unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import types
 import unittest
 from unittest.mock import patch
 
 import fiftyone.core.utils as fou
-
 
 _GiB = 1024**3
 

--- a/tests/unittests/metadata_tests.py
+++ b/tests/unittests/metadata_tests.py
@@ -5,6 +5,7 @@ FiftyOne metadata unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import io
 import os
 import tempfile

--- a/tests/unittests/model_tests.py
+++ b/tests/unittests/model_tests.py
@@ -5,6 +5,7 @@ FiftyOne model inference unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import random
 import string

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -5,6 +5,7 @@ FiftyOne odm unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 from bson import ObjectId

--- a/tests/unittests/ontology_delete_tests.py
+++ b/tests/unittests/ontology_delete_tests.py
@@ -17,7 +17,6 @@ from fiftyone.core.ontology import (
     delete_ontology,
 )
 
-
 _ONTOLOGY_NAME = "test_ontology"
 
 

--- a/tests/unittests/operators/decorators_tests.py
+++ b/tests/unittests/operators/decorators_tests.py
@@ -5,6 +5,7 @@ Unit tests for operators/decorators.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import asyncio
 import os
 import shutil

--- a/tests/unittests/operators/delegated_tests.py
+++ b/tests/unittests/operators/delegated_tests.py
@@ -2182,7 +2182,7 @@ class TestPipelineRequestParamsOverrides(unittest.TestCase):
                     PipelineStage(
                         operator_uri="@test/op1",
                         name="stage_one",
-                        params={"stage_param": "value1"}
+                        params={"stage_param": "value1"},
                         # No request_params_overrides
                     ),
                 ]
@@ -2289,7 +2289,7 @@ class TestPipelineRequestParamsOverrides(unittest.TestCase):
                     PipelineStage(
                         operator_uri="@test/op2",
                         name="stage_two",
-                        request_params_overrides={"field2": "value2"}
+                        request_params_overrides={"field2": "value2"},
                         # view_name should NOT carry forward from stage 1
                     ),
                 ]
@@ -2355,7 +2355,7 @@ class TestPipelineRequestParamsOverrides(unittest.TestCase):
                         params={"param2": "value2"},
                         request_params_overrides={
                             "view_name": "custom_view_2",
-                        }
+                        },
                         # custom_field should NOT be present here
                     ),
                     PipelineStage(

--- a/tests/unittests/plugins/context_tests.py
+++ b/tests/unittests/plugins/context_tests.py
@@ -141,14 +141,12 @@ class TestPluginRegistration:
             f.write("VALUE = 42\n")
 
         with open(plugin_dir / "__init__.py", "w") as f:
-            f.write(
-                """
+            f.write("""
 from .utils import VALUE
 
 def register(ctx):
     ctx.test_value = VALUE
-"""
-            )
+""")
 
         metadata = {
             "name": "@myorg/myplugin",
@@ -179,8 +177,7 @@ def register(ctx):
             f.write("HELPER_VALUE = 99\n")
 
         with open(plugin_dir / "__init__.py", "w") as f:
-            f.write(
-                """
+            f.write("""
 import importlib
 
 def register(ctx):
@@ -189,8 +186,7 @@ def register(ctx):
         "fiftyone.plugins.orgs.testorg.testplugin.helpers"
     )
     ctx.helper_value = helpers.HELPER_VALUE
-"""
-            )
+""")
 
         metadata = {
             "name": "@testorg/testplugin",

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -19,7 +19,6 @@ import fiftyone.plugins.definitions as fpd
 import fiftyone.plugins.constants as fpc
 import fiftyone.utils.github as foug
 
-
 _DEFAULT_TEST_PLUGINS = ["test-plugin1", "test-plugin2"]
 _DEFAULT_APP_CONFIG = {}
 _REQUIRED_YML_KEYS = ["name", "label", "version"]

--- a/tests/unittests/plugins/secrets_tests.py
+++ b/tests/unittests/plugins/secrets_tests.py
@@ -17,7 +17,6 @@ from fiftyone.internal.secrets import UnencryptedSecret
 from fiftyone.operators import Operator
 from fiftyone.operators.executor import ExecutionContext
 
-
 SECRET_KEY = "MY_SECRET_KEY"
 SECRET_KEY2 = "MY_SECRET_KEY2"
 SECRET_VALUE = "password123"

--- a/tests/unittests/plugins/skills_tests.py
+++ b/tests/unittests/plugins/skills_tests.py
@@ -15,7 +15,6 @@ import pytest
 import fiftyone.plugins as fop
 import fiftyone.plugins.skills as fps
 
-
 _DEFAULT_APP_CONFIG = {}
 
 _SKILL_MD = """\

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -5,6 +5,7 @@ FiftyOne run-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import fiftyone as fo

--- a/tests/unittests/server/routes/test_ontology.py
+++ b/tests/unittests/server/routes/test_ontology.py
@@ -199,17 +199,13 @@ def _save_taxonomy(name, root_dict):
 
 class TestOntologyTaxonomyRoute:
     @pytest.mark.asyncio
-    async def test_unknown_name_404(
-        self, taxonomy_endpoint, taxonomy_request
-    ):
+    async def test_unknown_name_404(self, taxonomy_endpoint, taxonomy_request):
         with pytest.raises(HTTPException) as exc:
             await taxonomy_endpoint.get(taxonomy_request("does_not_exist"))
         assert exc.value.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_non_taxonomy_404(
-        self, taxonomy_endpoint, taxonomy_request
-    ):
+    async def test_non_taxonomy_404(self, taxonomy_endpoint, taxonomy_request):
         from fiftyone.core.ontology import AnnotationOntology
 
         AnnotationOntology(name="some_ao").save()
@@ -241,9 +237,7 @@ class TestOntologyTaxonomyRoute:
         assert body["taxonomy"]["name"] == "vehicle_classes"
         assert body["taxonomy"]["type"] == "taxonomy"
         assert body["taxonomy"]["root"]["name"] == "root"
-        child_names = [
-            c["name"] for c in body["taxonomy"]["root"]["values"]
-        ]
+        child_names = [c["name"] for c in body["taxonomy"]["root"]["values"]]
         assert child_names == ["car", "truck"]
 
     @pytest.mark.asyncio
@@ -275,9 +269,7 @@ class TestOntologyTaxonomyRoute:
         assert names == ["sedan", "suv"]
 
     @pytest.mark.asyncio
-    async def test_unknown_node_404(
-        self, taxonomy_endpoint, taxonomy_request
-    ):
+    async def test_unknown_node_404(self, taxonomy_endpoint, taxonomy_request):
         _save_taxonomy(
             "vehicle_classes", {"name": "root", "values": [{"name": "car"}]}
         )
@@ -300,9 +292,7 @@ class TestOntologyTaxonomyRoute:
         )
 
         response = await taxonomy_endpoint.get(
-            taxonomy_request(
-                "vehicle_classes", query_params={"depth": "0"}
-            )
+            taxonomy_request("vehicle_classes", query_params={"depth": "0"})
         )
 
         body = json.loads(response.body)
@@ -327,9 +317,7 @@ class TestOntologyTaxonomyRoute:
         )
 
         response = await taxonomy_endpoint.get(
-            taxonomy_request(
-                "vehicle_classes", query_params={"depth": "1"}
-            )
+            taxonomy_request("vehicle_classes", query_params={"depth": "1"})
         )
 
         body = json.loads(response.body)
@@ -351,9 +339,7 @@ class TestOntologyTaxonomyRoute:
         )
 
         response = await taxonomy_endpoint.get(
-            taxonomy_request(
-                "vehicle_classes", query_params={"depth": "1"}
-            )
+            taxonomy_request("vehicle_classes", query_params={"depth": "1"})
         )
 
         body = json.loads(response.body)

--- a/tests/unittests/server/routes/test_runtime_assets.py
+++ b/tests/unittests/server/routes/test_runtime_assets.py
@@ -30,19 +30,28 @@ class TestGetModelBaseUrl:
 
     def test_env_override(self, monkeypatch):
         """Tests that an environment variable overrides the default URL."""
-        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_SAM2", "https://custom.example.com/sam2")
+        monkeypatch.setenv(
+            "FIFTYONE_MODEL_WEIGHTS_BASE_SAM2",
+            "https://custom.example.com/sam2",
+        )
         url = _get_model_base_url("sam2")
         assert url == "https://custom.example.com/sam2"
 
     def test_env_override_strips_trailing_slash(self, monkeypatch):
         """Tests that a trailing slash on the env var value is stripped."""
-        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_SAM2", "https://custom.example.com/sam2/")
+        monkeypatch.setenv(
+            "FIFTYONE_MODEL_WEIGHTS_BASE_SAM2",
+            "https://custom.example.com/sam2/",
+        )
         url = _get_model_base_url("sam2")
         assert url == "https://custom.example.com/sam2"
 
     def test_env_key_uppercases_family(self, monkeypatch):
         """Tests that the family name is upper-cased when building the env key."""
-        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_MYMODEL", "https://example.com/mymodel")
+        monkeypatch.setenv(
+            "FIFTYONE_MODEL_WEIGHTS_BASE_MYMODEL",
+            "https://example.com/mymodel",
+        )
         url = _get_model_base_url("mymodel")
         assert url == "https://example.com/mymodel"
 
@@ -93,9 +102,14 @@ class TestModelWeightsEndpoint:
         assert data["url"] == f"{DEFAULT_MODEL_URLS['sam2']}/subdir/model.onnx"
 
     @pytest.mark.asyncio
-    async def test_env_override_reflected_in_response(self, endpoint, monkeypatch):
+    async def test_env_override_reflected_in_response(
+        self, endpoint, monkeypatch
+    ):
         """Tests that an env var override is used in the response URL."""
-        monkeypatch.setenv("FIFTYONE_MODEL_WEIGHTS_BASE_SAM2", "https://private.cdn.com/models")
+        monkeypatch.setenv(
+            "FIFTYONE_MODEL_WEIGHTS_BASE_SAM2",
+            "https://private.cdn.com/models",
+        )
         request = _make_request("sam2", "decoder.onnx")
         response = await endpoint.get(request)
 

--- a/tests/unittests/server/utils/jsonpatch/test_jsonpatch.py
+++ b/tests/unittests/server/utils/jsonpatch/test_jsonpatch.py
@@ -242,8 +242,13 @@ class TestApplyInstanceId:
 
         result, errors = jsonpatch.apply(
             detections,
-            [{"op": "replace", "path": "/detections/0/instance/_id",
-              "value": new_id}],
+            [
+                {
+                    "op": "replace",
+                    "path": "/detections/0/instance/_id",
+                    "value": new_id,
+                }
+            ],
         )
 
         assert errors == []
@@ -261,10 +266,16 @@ class TestApplyInstanceId:
         result, errors = jsonpatch.apply(
             detections,
             [
-                {"op": "replace", "path": "/detections/0/_id",
-                 "value": str(det1.id)},
-                {"op": "replace", "path": "/detections/0/instance/_id",
-                 "value": str(det1.instance.id)},
+                {
+                    "op": "replace",
+                    "path": "/detections/0/_id",
+                    "value": str(det1.id),
+                },
+                {
+                    "op": "replace",
+                    "path": "/detections/0/instance/_id",
+                    "value": str(det1.instance.id),
+                },
                 {"op": "remove", "path": "/detections/1"},
             ],
         )

--- a/tests/unittests/similarity_tests.py
+++ b/tests/unittests/similarity_tests.py
@@ -5,6 +5,7 @@ FiftyOne visual similarity-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 
 import numpy as np

--- a/tests/unittests/synchronization_tests.py
+++ b/tests/unittests/synchronization_tests.py
@@ -5,6 +5,7 @@ FiftyOne synchronization-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import unittest
 

--- a/tests/unittests/torch_dataset_tests.py
+++ b/tests/unittests/torch_dataset_tests.py
@@ -5,6 +5,7 @@ FiftyOne torch dataset unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import unittest
 

--- a/tests/unittests/uid_tests.py
+++ b/tests/unittests/uid_tests.py
@@ -5,6 +5,7 @@ FiftyOne user ID utility unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import unittest
 import uuid
 from unittest.mock import patch, mock_open

--- a/tests/unittests/utils/groups.py
+++ b/tests/unittests/utils/groups.py
@@ -5,6 +5,7 @@ FiftyOne group test utils
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import fiftyone as fo
 
 

--- a/tests/unittests/utils/openlabel.py
+++ b/tests/unittests/utils/openlabel.py
@@ -5,6 +5,7 @@ FiftyOne OpenLABEL test utils
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 import os
 

--- a/tests/unittests/utils/test_ultralytics.py
+++ b/tests/unittests/utils/test_ultralytics.py
@@ -23,8 +23,12 @@ class TestDetectionsToVisualPrompts:
         original_bbox_b = [0.5, 0.0, 0.5, 1.0]
         dets = fol.Detections(
             detections=[
-                fol.Detection(label="person", bounding_box=list(original_bbox_a)),
-                fol.Detection(label="person", bounding_box=list(original_bbox_b)),
+                fol.Detection(
+                    label="person", bounding_box=list(original_bbox_a)
+                ),
+                fol.Detection(
+                    label="person", bounding_box=list(original_bbox_b)
+                ),
             ]
         )
 
@@ -188,7 +192,10 @@ class TestFiftyOneYOLOEVPCollate:
 
         from fiftyone.utils.ultralytics import FiftyOneYOLOEVPModel
 
-        vp_a = {"bboxes": np.array([[0.0, 0.0, 1.0, 1.0]]), "cls": np.array([0])}
+        vp_a = {
+            "bboxes": np.array([[0.0, 0.0, 1.0, 1.0]]),
+            "cls": np.array([0]),
+        }
         classes_a = ["dog"]
         vp_b = None
         classes_b = None
@@ -451,8 +458,8 @@ class TestFiftyOneYOLOEVPVisualPrompts:
         # Stub _set_predictor: parent's implementation requires a real
         # ultralytics model. Tests inspect _set_predictor_calls.
         model._set_predictor_calls = []
-        model._set_predictor = lambda config, m: model._set_predictor_calls.append(
-            (config, m)
+        model._set_predictor = (
+            lambda config, m: model._set_predictor_calls.append((config, m))
         )
 
         # Recording mock for self._output_processor. Captures every call and
@@ -477,9 +484,7 @@ class TestFiftyOneYOLOEVPVisualPrompts:
                     "classes": classes,
                 }
             )
-            label = (
-                f"out-{vp_classes[0]}" if vp_classes else "no-vp"
-            )
+            label = f"out-{vp_classes[0]}" if vp_classes else "no-vp"
             return [
                 fol.Detections(
                     detections=[
@@ -605,9 +610,7 @@ class TestFiftyOneYOLOEVPVisualPrompts:
 
         vp = {"bboxes": np.array([[0.0, 0.0, 1.0, 1.0]]), "cls": np.array([0])}
 
-        model._predict_all_visual_prompts(
-            ["A", "B"], [vp, vp], [["x"], ["x"]]
-        )
+        model._predict_all_visual_prompts(["A", "B"], [vp, vp], [["x"], ["x"]])
 
         assert model._set_predictor_calls == [(model.config, model._model)]
 

--- a/tests/unittests/video_keyframe_sync_tests.py
+++ b/tests/unittests/video_keyframe_sync_tests.py
@@ -17,16 +17,20 @@ class KeyframeSyncTests(unittest.TestCase):
         )
         sample.frames[1] = fo.Frame(
             filepath="frame1.jpg",
-            detections=fo.Detections(detections=[
-                fo.Detection(
-                    label="car",
-                    bounding_box=[0.1, 0.1, 0.2, 0.2],
-                ),
-            ])
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="car",
+                        bounding_box=[0.1, 0.1, 0.2, 0.2],
+                    ),
+                ]
+            ),
         )
-        sample["events"] = fo.TemporalDetections(detections=[
-            fo.TemporalDetection(label="action", support=[1, 3]),
-        ])
+        sample["events"] = fo.TemporalDetections(
+            detections=[
+                fo.TemporalDetection(label="action", support=[1, 3]),
+            ]
+        )
         self.dataset.add_sample(sample)
         self.sample: fo.Sample = sample
 
@@ -106,8 +110,9 @@ class KeyframeSyncTests(unittest.TestCase):
             [parent_a, parent_b],
         )
 
-
-    def test_keyframe_dynamic_attr_persists_on_temporal_detection(self) -> None:
+    def test_keyframe_dynamic_attr_persists_on_temporal_detection(
+        self,
+    ) -> None:
         td: fo.TemporalDetection = self.sample.events.detections[0]
         td.keyframe = True
         td.propagation = None

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -5268,7 +5268,7 @@ class ViewStageTests(unittest.TestCase):
         self.assertEqual(type(second_stage), fosg.Select)
 
     def test_selected_samples_in_group_slices(self):
-        (dataset, selected_ids) = self._make_group_by_group_dataset()
+        dataset, selected_ids = self._make_group_by_group_dataset()
         view = dataset.view()
         self.assertEqual(view.media_type, "group")
 

--- a/tests/utils/command_wrapper.py
+++ b/tests/utils/command_wrapper.py
@@ -5,11 +5,11 @@ Wrapper around an arbitrary command that cleans up subprocesses.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import subprocess
 import sys
 
 import psutil
-
 
 try:
     subprocess.check_call(sys.argv[1:])

--- a/tests/utils/interactive_python.py
+++ b/tests/utils/interactive_python.py
@@ -6,11 +6,11 @@ execute. For use by service tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 
 os.environ["FIFTYONE_DISABLE_SERVICES"] = "1"
 from fiftyone.service.ipc import IPCServer
-
 
 env = {}
 

--- a/tests/utils/pytest_wrapper.py
+++ b/tests/utils/pytest_wrapper.py
@@ -5,6 +5,7 @@ Wrapper around pytest that cleans up subprocesses.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import sys
 
 import psutil

--- a/tests/utils/setup_config.py
+++ b/tests/utils/setup_config.py
@@ -5,13 +5,13 @@ Sets up configuration for tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 
 os.environ["FIFTYONE_DISABLE_SERVICES"] = "1"
 
 from fiftyone import config
 from fiftyone.constants import FIFTYONE_CONFIG_PATH
-
 
 config.show_progress_bars = False
 config.write_json(FIFTYONE_CONFIG_PATH)

--- a/tools/pgrep.py
+++ b/tools/pgrep.py
@@ -3,6 +3,7 @@ A very basic reimplementation of the Unix `pgrep` command that works on Windows.
 
 For supported options, run with --help.
 """
+
 import argparse
 import psutil
 


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

CI does not check Python formatting today. The pre-commit hook pins black 22.3.0, which no longer matches what developers have installed, so hooks and local formatters disagree and unrelated formatting hunks leak into PRs.

- **Pin black 26.5.1** in `.pre-commit-config.yaml`, and blacken-docs 1.20.0 on the same black. `pyproject.toml` gains `extend-exclude` for `docs/theme` and `__generated__`, mirroring the hook's excludes, so a plain `black .` and the hook agree.
- **Reformat once** under 26.5.1, as its own commit (`Reformat with black 26.5.1`): 283 Python files plus `STYLE_GUIDE.md` code blocks via blacken-docs. Mechanical; review the first commit, skim the second.
- **`lint-python` job** in `.github/workflows/pr.yml`. Runs when any `*.py`, `pyproject.toml`, or `.pre-commit-config.yaml` changes, installs pre-commit, and runs the black hook over the tree with a diff on failure. It joins `ci-comment` and `all-tests` `needs`, the no-op mirror's suite regex, and the final aggregate condition, so it gates merges the same way `lint` does.

## 🧪 How is this patch tested? If it is not, please explain why.

- `pre-commit run black --all-files` and `pre-commit run blacken-docs --all-files` pass on the branch.
- `black --check .` with black 26.5.1 reports 608 files unchanged; nothing under `docs/theme` or `__generated__` was touched.
- `pr.yml` parses, and the new job appears in every `needs` list that includes `lint`.
- The `lint-python` job itself runs for the first time on this PR.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4050
<!-- enterprise-sync-pr:end -->