### PR TITLE
[release/v1.22.0] Annotate: number native-decode frames from the edit list's presentation start

### DIFF
--- a/app/packages/video-annotation/src/streams/editList.test.ts
+++ b/app/packages/video-annotation/src/streams/editList.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { presentationStart, presentedInOrder } from "./editList";
+
+describe("presentationStart", () => {
+  it("is undefined without an edit list", () => {
+    expect(presentationStart(undefined)).toBeUndefined();
+    expect(presentationStart([])).toBeUndefined();
+  });
+
+  it("is the media_time of the first edit", () => {
+    expect(
+      presentationStart([{ segment_duration: 9120, media_time: 96000 }]),
+    ).toBe(96000);
+  });
+
+  it("skips a leading empty edit", () => {
+    expect(
+      presentationStart([
+        { segment_duration: 500, media_time: -1 },
+        { segment_duration: 9120, media_time: 96000 },
+      ]),
+    ).toBe(96000);
+  });
+
+  it("is undefined when every edit is empty", () => {
+    expect(
+      presentationStart([{ segment_duration: 500, media_time: -1 }]),
+    ).toBeUndefined();
+  });
+});
+
+describe("presentedInOrder", () => {
+  // 5 fps in a 1.2 MHz track timescale: one frame every 240000 ticks.
+  const FRAME = 240000;
+  const samples = [0, 1, 2, 3].map((i) => ({ cts: i * FRAME, id: i }));
+
+  it("numbers every sample when there is no edit list", () => {
+    expect(presentedInOrder(samples, undefined).map((s) => s.id)).toEqual([
+      0, 1, 2, 3,
+    ]);
+  });
+
+  it("keeps negative-cts samples when there is no edit list", () => {
+    // Signed composition offsets without an edit list: no boundary applies.
+    const signed = [
+      { cts: 0, id: "I" },
+      { cts: 2 * FRAME, id: "P" },
+      { cts: -FRAME, id: "B" },
+    ];
+    expect(presentedInOrder(signed, undefined).map((s) => s.id)).toEqual([
+      "B",
+      "I",
+      "P",
+    ]);
+    // An explicit boundary at 0 still drops them.
+    expect(presentedInOrder(signed, 0).map((s) => s.id)).toEqual(["I", "P"]);
+  });
+
+  it("drops samples before the presentation start as pre-roll", () => {
+    // Edit list starts 0.08 s in: picture 1 (cts 0) is pre-roll, frame 1 is picture 2.
+    expect(presentedInOrder(samples, 96000).map((s) => s.id)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("keeps a sample that starts exactly at the presentation start", () => {
+    expect(presentedInOrder(samples, FRAME).map((s) => s.id)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("orders by composition time, not decode order", () => {
+    // B-frame reordering: decode order I P B B, presentation order I B B P.
+    const reordered = [
+      { cts: 0, id: "I" },
+      { cts: 3 * FRAME, id: "P" },
+      { cts: 1 * FRAME, id: "B1" },
+      { cts: 2 * FRAME, id: "B2" },
+    ];
+    expect(presentedInOrder(reordered, 0).map((s) => s.id)).toEqual([
+      "I",
+      "B1",
+      "B2",
+      "P",
+    ]);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [{ cts: FRAME }, { cts: 0 }];
+    presentedInOrder(input, 0);
+    expect(input.map((s) => s.cts)).toEqual([FRAME, 0]);
+  });
+});

--- a/app/packages/video-annotation/src/streams/editList.ts
+++ b/app/packages/video-annotation/src/streams/editList.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * mp4 edit-list (`elst`) numbering. Samples before the edit list's media start
+ * are pre-roll: ffmpeg decodes them for reference and never emits them, so
+ * frame 1 is the first sample at or after the start. `to_frames`, OpenCV, and
+ * backend inference inherit that numbering; Annotate must match it.
+ */
+
+/** One `elst` entry, as mp4box exposes it on `Track.edits`. */
+export interface EditListEntry {
+  /** Movie timescale units. */
+  segment_duration: number;
+  /** Track timescale units; `-1` marks an empty edit. */
+  media_time: number;
+}
+
+/**
+ * Media time where presentation begins: the first non-empty edit's
+ * `media_time`. `undefined` without an edit list — no boundary, so every
+ * sample is presented, including ones with negative `cts`.
+ */
+export function presentationStart(
+  edits: readonly EditListEntry[] | undefined,
+): number | undefined {
+  return edits?.find((edit) => edit.media_time >= 0)?.media_time;
+}
+
+/** Sample composition time, in track timescale units. */
+export interface TimedSample {
+  cts: number;
+}
+
+/** Samples at or after `start` (all, if none), in presentation order. Frame `n` is element `n - 1`. */
+export function presentedInOrder<T extends TimedSample>(
+  samples: readonly T[],
+  start: number | undefined,
+): T[] {
+  const presented =
+    start === undefined ? [...samples] : samples.filter((s) => s.cts >= start);
+  return presented.sort((a, b) => a.cts - b.cts);
+}

--- a/app/packages/video-annotation/src/streams/mp4box.d.ts
+++ b/app/packages/video-annotation/src/streams/mp4box.d.ts
@@ -41,6 +41,15 @@ declare module "mp4box" {
     track_width: number;
     track_height: number;
     type?: "audio" | "video" | "subtitles" | "metadata";
+    /** `elst` entries, when the track has an edit list. */
+    edits?: Array<{
+      /** Movie timescale units. */
+      segment_duration: number;
+      /** Track timescale units; `-1` marks an empty edit. */
+      media_time: number;
+      media_rate_integer: number;
+      media_rate_fraction: number;
+    }>;
   }
 
   export interface Movie {

--- a/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
+++ b/app/packages/video-annotation/src/streams/videoDecodeWorker.ts
@@ -22,7 +22,8 @@
  * each frame's presentation timestamp (`cts`) to a 1-indexed frame number. We
  * stamp every `EncodedVideoChunk` with that timestamp; the decoder echoes it
  * onto the output `VideoFrame`, so we can assign the correct frame number on
- * the way out regardless of decode order (B-frames) or GOP boundaries.
+ * the way out regardless of decode order (B-frames) or GOP boundaries. Frame
+ * 1 is the first sample at or after the edit list's start, as in ffmpeg.
  *
  * GOP handling lives entirely here (the stream base stays source-agnostic): a
  * chunk request for presentation frames `[start, start+n)` is snapped back to
@@ -44,6 +45,11 @@ import type {
   FrameWorkerOutbound,
   InitMessage,
 } from "./frameWorkerProtocol";
+import {
+  type EditListEntry,
+  presentationStart,
+  presentedInOrder,
+} from "./editList";
 import {
   ByteRangeCache,
   type ByteRange,
@@ -207,7 +213,7 @@ async function initSampleTable(
     throw new Error("demux produced no samples");
   }
 
-  buildSampleTable(samples, track.timescale);
+  buildSampleTable(samples, track.timescale, track.edits);
 }
 
 /**
@@ -318,13 +324,18 @@ async function streamMoov(
 }
 
 /**
- * Turn raw demuxed samples into `decodeOrder` (decode order, as delivered),
- * assign each its 1-indexed presentation frame number (sort by `cts`), and
- * build the µs→frame map + keyframe index list.
+ * Build `decodeOrder` (as delivered), number the presented samples 1..N by
+ * `cts`, and index keyframes. Pre-roll samples stay in `decodeOrder` — the GOP
+ * keyframe is usually one — but get no frame number, so {@link onDecoderOutput}
+ * drops their output.
  */
-function buildSampleTable(samples: Sample[], timescale: number): void {
+function buildSampleTable(
+  samples: Sample[],
+  timescale: number,
+  edits: readonly EditListEntry[] | undefined,
+): void {
   decodeOrder = samples.map((s, decodeIndex) => ({
-    frameNumber: 0, // filled below once we know presentation order
+    frameNumber: 0,
     decodeIndex,
     tsMicros: Math.round((s.cts * 1e6) / timescale),
     durMicros: Math.round((s.duration * 1e6) / timescale),
@@ -333,9 +344,12 @@ function buildSampleTable(samples: Sample[], timescale: number): void {
     size: s.size,
   }));
 
-  // Presentation order = ascending composition timestamp. 1-indexed frame
-  // numbers match `to_frames` / looker's ImaVid numbering (frame 1 = t≈0).
-  byFrameNumber = [...decodeOrder].sort((a, b) => a.tsMicros - b.tsMicros);
+  const presented = presentedInOrder(
+    samples.map((s, decodeIndex) => ({ cts: s.cts, decodeIndex })),
+    presentationStart(edits),
+  );
+
+  byFrameNumber = presented.map((p) => decodeOrder[p.decodeIndex]);
   byFrameNumber.forEach((sample, i) => {
     sample.frameNumber = i + 1;
     microsToFrame.set(sample.tsMicros, sample.frameNumber);
@@ -345,7 +359,7 @@ function buildSampleTable(samples: Sample[], timescale: number): void {
     .filter((s) => s.isSync)
     .map((s) => s.decodeIndex);
 
-  totalFrames = decodeOrder.length;
+  totalFrames = byFrameNumber.length;
 }
 
 /**


### PR DESCRIPTION
Cherry-pick of #8410.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video frame ordering and timing for MP4 files with edit lists.
  - Corrected frame counting and identification of the first presented frame, including pre-roll and negative timestamp cases.

- **Tests**
  - Added comprehensive coverage for edit-list timing, presentation boundaries, composition-time ordering, empty lists, and input immutability.

- **Documentation**
  - Clarified how the first frame is determined when MP4 edit-list metadata is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->