### PR TITLE
Fix overflow menu overlaying modal

### DIFF
--- a/app/packages/operators/src/OperatorPlacements.test.tsx
+++ b/app/packages/operators/src/OperatorPlacements.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// An operator launched from the action row's overflow popout opens the
+// operator palette, which the popout would otherwise cover
+
+const promptForInput = vi.fn();
+const execute = vi.fn();
+
+vi.mock("@fiftyone/components", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+  Link: "a",
+  PillButton: ({ onClick, title }: { onClick: () => void; title: string }) => (
+    <button onClick={onClick} type="button">
+      {title}
+    </button>
+  ),
+}));
+vi.mock("@fiftyone/core/src/components/Actions/utils", () => ({
+  getStringAndNumberProps: () => ({}),
+}));
+vi.mock("@fiftyone/plugins", () => ({
+  PluginComponentType: { Component: "component" },
+  useActivePlugins: () => [],
+}));
+vi.mock("@fiftyone/state", () => ({
+  withSuspense: (component: unknown) => component,
+}));
+vi.mock("./OperatorIcon", () => ({ default: () => null }));
+vi.mock("./state", () => ({
+  useOperatorExecutor: () => ({ execute }),
+  useOperatorPlacements: () => ({ placements: [] }),
+  usePromptOperatorInput: () => promptForInput,
+}));
+vi.mock(".", () => ({
+  types: { Places: { SAMPLES_GRID_ACTIONS: "samples-grid-actions" } },
+}));
+
+import { OperatorPlacementWithErrorBoundary } from "./OperatorPlacements";
+
+const URI = "@voxel51/yolo/finetune";
+
+const renderPlacement = (closeOverflow?: () => void) =>
+  render(
+    <OperatorPlacementWithErrorBoundary
+      place={"samples-grid-actions" as never}
+      operator={
+        { uri: URI, name: "finetune", label: "Finetune YOLOv8" } as never
+      }
+      placement={{ view: { name: "Button" } } as never}
+      adaptiveMenuItemProps={
+        closeOverflow ? { variant: "overflow", closeOverflow } : undefined
+      }
+    />,
+  );
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("operator placements", () => {
+  it("closes the overflow popout when the operator is launched from it", () => {
+    const closeOverflow = vi.fn();
+    renderPlacement(closeOverflow);
+
+    fireEvent.click(screen.getByRole("button", { name: "Finetune YOLOv8" }));
+
+    expect(closeOverflow).toHaveBeenCalledTimes(1);
+    expect(promptForInput).toHaveBeenCalledWith(URI);
+  });
+
+  it("launches the operator when the row has no overflow", () => {
+    renderPlacement();
+
+    fireEvent.click(screen.getByRole("button", { name: "Finetune YOLOv8" }));
+
+    expect(promptForInput).toHaveBeenCalledWith(URI);
+  });
+});

--- a/app/packages/operators/src/OperatorPlacements.test.tsx
+++ b/app/packages/operators/src/OperatorPlacements.test.tsx
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Mock } from "vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // An operator launched from the action row's overflow popout opens the
 // operator palette, which the popout would otherwise cover
 
-const promptForInput = vi.fn();
-const execute = vi.fn();
+// vi.mock factories are evaluated before module-scope consts, so the spies
+// they close over live in vi.hoisted()
+const { execute, promptForInput } = vi.hoisted(() => ({
+  execute: vi.fn(),
+  promptForInput: vi.fn(),
+}));
 
 vi.mock("@fiftyone/components", () => ({
   ErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
@@ -41,19 +46,28 @@ import { OperatorPlacementWithErrorBoundary } from "./OperatorPlacements";
 
 const URI = "@voxel51/yolo/finetune";
 
-const renderPlacement = (closeOverflow?: () => void) =>
+const renderPlacement = ({
+  closeOverflow,
+  prompt = true,
+}: { closeOverflow?: () => void; prompt?: boolean } = {}) =>
   render(
     <OperatorPlacementWithErrorBoundary
       place={"samples-grid-actions" as never}
       operator={
         { uri: URI, name: "finetune", label: "Finetune YOLOv8" } as never
       }
-      placement={{ view: { name: "Button" } } as never}
+      placement={{ view: { name: "Button", options: { prompt } } } as never}
       adaptiveMenuItemProps={
         closeOverflow ? { variant: "overflow", closeOverflow } : undefined
       }
     />,
   );
+
+const launch = () =>
+  fireEvent.click(screen.getByRole("button", { name: "Finetune YOLOv8" }));
+
+const calledBefore = (first: Mock, second: Mock) =>
+  first.mock.invocationCallOrder[0] < second.mock.invocationCallOrder[0];
 
 afterEach(() => {
   cleanup();
@@ -63,19 +77,40 @@ afterEach(() => {
 describe("operator placements", () => {
   it("closes the overflow popout when the operator is launched from it", () => {
     const closeOverflow = vi.fn();
-    renderPlacement(closeOverflow);
+    renderPlacement({ closeOverflow });
 
-    fireEvent.click(screen.getByRole("button", { name: "Finetune YOLOv8" }));
+    launch();
 
     expect(closeOverflow).toHaveBeenCalledTimes(1);
     expect(promptForInput).toHaveBeenCalledWith(URI);
+    expect(calledBefore(closeOverflow, promptForInput)).toBe(true);
   });
 
   it("launches the operator when the row has no overflow", () => {
     renderPlacement();
 
-    fireEvent.click(screen.getByRole("button", { name: "Finetune YOLOv8" }));
+    launch();
 
     expect(promptForInput).toHaveBeenCalledWith(URI);
+  });
+
+  it("executes without prompting when the placement opts out", () => {
+    renderPlacement({ prompt: false });
+
+    launch();
+
+    expect(execute).toHaveBeenCalledWith({});
+    expect(promptForInput).not.toHaveBeenCalled();
+  });
+
+  it("closes the overflow popout when an unprompted operator is launched from it", () => {
+    const closeOverflow = vi.fn();
+    renderPlacement({ closeOverflow, prompt: false });
+
+    launch();
+
+    expect(closeOverflow).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith({});
+    expect(calledBefore(closeOverflow, execute)).toBe(true);
   });
 });

--- a/app/packages/operators/src/OperatorPlacements.tsx
+++ b/app/packages/operators/src/OperatorPlacements.tsx
@@ -184,21 +184,25 @@ function ComponentPlacement(props: OperatorPlacementProps) {
 }
 
 export function usePlacementControls(props: OperatorPlacementProps) {
-  const { operator, placement } = props;
+  const { operator, placement, adaptiveMenuItemProps } = props;
   const { prompt = true } = placement?.view?.options || {};
   const { uri } = operator;
   const canExecute = operator?.config?.canExecute;
 
   const promptForInput = usePromptOperatorInput();
   const { execute } = useOperatorExecutor(uri);
+  const closeOverflow = adaptiveMenuItemProps?.closeOverflow;
 
   const handleClick = useCallback(() => {
+    // The action row's overflow popout outranks the operator palette, so one
+    // left open covers the prompt this click just opened
+    closeOverflow?.();
     if (prompt) {
       promptForInput(uri);
     } else {
       execute({});
     }
-  }, [prompt, promptForInput, uri, execute]);
+  }, [closeOverflow, prompt, promptForInput, uri, execute]);
 
   return { canExecute, execute: handleClick };
 }


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `main`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/main/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues


## 📋 What changes are proposed in this pull request?

- Close the overflow menu upon selection so it doesn't overlay the modal 


## 🧪 How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/3891f846-72f3-4376-9c45-143d92172628



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved operator placement behavior when launched from an overflow menu.
  - Overflow menus now close before prompting for operator input or executing an operator without input.
  - Operator clicks reliably launch the selected operator, including placements with overflow-menu actions.

- **Tests**
  - Added coverage for operator placement clicks with and without overflow-menu options, including verification that open menus close appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4045
<!-- enterprise-sync-pr:end -->