### PR TITLE
annotation: source the write version token from the latest server response

### DIFF
--- a/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.test.tsx
+++ b/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@fiftyone/state", () => ({
+  isGeneratedView: "isGeneratedView",
+  nullableModalSampleId: "nullableModalSampleId",
+  useCurrentDatasetId: () => "dataset-1",
+  useModalSample: () => ({ sample: { _id: "sample-1" } }),
+  useRefreshSample: () => vi.fn(),
+  useStableInteraction3dSample: () => undefined,
+}));
+
+vi.mock("recoil", () => ({
+  useRecoilValue: (key: string) =>
+    key === "isGeneratedView" ? false : undefined,
+}));
+
+vi.mock("./useAnnotationDeltaSupplier", () => ({
+  useAnnotationDeltaSupplier: () => () => ({ deltas: [], metadata: null }),
+}));
+
+const patchSelected = vi.fn();
+
+vi.mock("../hooks", () => ({
+  useAnnotationEventBus: () => ({ dispatch: vi.fn() }),
+  useGetVersionTokenWith: () => () => "token",
+  usePatchSample: () => patchSelected,
+  usePatchSampleWith: () => vi.fn(),
+}));
+
+const engine = {
+  getJsonPatch: vi.fn(),
+  captureBaseline: vi.fn(),
+  reconcilePersisted: vi.fn(),
+  getPersistenceAdapter: () => undefined,
+};
+
+vi.mock("../state", () => ({
+  useAnnotationEngine: () => engine,
+  useThreeDSceneSampleId: () => undefined,
+}));
+
+import { usePersistAnnotationDeltas } from "./usePersistAnnotationDeltas";
+
+const DELTAS = [{ op: "replace", path: "/x", value: 1 }];
+
+describe("usePersistAnnotationDeltas", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    engine.getJsonPatch.mockReturnValue([
+      { sample: "sample-1", deltas: DELTAS },
+    ]);
+  });
+
+  it("a second persist waits for the in-flight one before reading the engine", async () => {
+    let finishFirst!: (ok: boolean) => void;
+    patchSelected
+      .mockImplementationOnce(
+        () => new Promise<boolean>((resolve) => (finishFirst = resolve)),
+      )
+      .mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => usePersistAnnotationDeltas());
+
+    const first = result.current();
+    const second = result.current();
+    await Promise.resolve();
+
+    // the second call has not touched the engine while the first is in flight
+    expect(engine.getJsonPatch).toHaveBeenCalledTimes(1);
+    expect(patchSelected).toHaveBeenCalledTimes(1);
+
+    finishFirst(true);
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+
+    // the first response was reconciled before the second read its deltas
+    expect(engine.reconcilePersisted).toHaveBeenCalledTimes(2);
+    expect(engine.getJsonPatch).toHaveBeenCalledTimes(2);
+    expect(engine.reconcilePersisted.mock.invocationCallOrder[0]).toBeLessThan(
+      engine.getJsonPatch.mock.invocationCallOrder[1],
+    );
+  });
+
+  it("a rejected persist does not block the next one", async () => {
+    patchSelected
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => usePersistAnnotationDeltas());
+
+    await expect(result.current()).rejects.toThrow("boom");
+    await expect(result.current()).resolves.toBe(true);
+  });
+});

--- a/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
+++ b/app/packages/annotation/src/persistence/usePersistAnnotationDeltas.ts
@@ -25,6 +25,16 @@ import { useAnnotationEngine, useThreeDSceneSampleId } from "../state";
 type PersistenceResult = boolean | null;
 
 /**
+ * The persist in flight per engine. Writers (the autosave tick, a delete's
+ * immediate flush) are independent callers, so without this two writes can
+ * interleave: the second computes its deltas and version token before the
+ * first's response has been reconciled, re-sends what the first already
+ * wrote, and fails the server's If-Match check. Each persist waits for the
+ * previous one, then reads the engine fresh.
+ */
+const inFlight = new WeakMap<object, Promise<unknown>>();
+
+/**
  * Hook which provides a callback to persist all pending annotation deltas.
  *
  * A grouped modal renders more than one sample at once (the selected slice and
@@ -75,7 +85,7 @@ export const usePersistAnnotationDeltas =
       generatedDatasetName: null,
     });
 
-    return useCallback(async () => {
+    const persist = useCallback(async (): Promise<PersistenceResult> => {
       // generated (patches) views are single-sample and route through
       // first-edited-label metadata, so the backend can find the source label
       if (isGenerated) {
@@ -165,4 +175,15 @@ export const usePersistAnnotationDeltas =
       sceneId,
       supplyAnnotationDeltas,
     ]);
+
+    return useCallback(() => {
+      const prior = inFlight.get(engine) ?? Promise.resolve();
+      const run = prior.then(persist);
+      inFlight.set(
+        engine,
+        run.catch(() => undefined),
+      );
+
+      return run;
+    }, [engine, persist]);
   };

--- a/app/packages/annotation/src/util/getSampleVersionToken.test.ts
+++ b/app/packages/annotation/src/util/getSampleVersionToken.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getSampleVersionToken } from "./getSampleVersionToken";
+import {
+  getSampleVersionToken,
+  recordSampleVersionToken,
+} from "./getSampleVersionToken";
 import type { Sample } from "@fiftyone/looker";
 
 vi.mock("@fiftyone/core/src/client/util", () => ({
@@ -63,11 +66,88 @@ describe("getSampleVersionToken", () => {
 
   it("should return ISO timestamp as-is when it does not end with Z", () => {
     const mockDate = {
+      getTime: () => 0,
       toISOString: () => "2024-01-15T10:30:00.000+00:00",
     } as Date;
     vi.mocked(parseTimestamp).mockReturnValue(mockDate);
 
     const result = getSampleVersionToken({ sample });
     expect(result).toBe("2024-01-15T10:30:00.000+00:00");
+  });
+
+  describe("with a server-confirmed version recorded", () => {
+    const OLDER = new Date("2026-09-09T14:16:24.457Z");
+    const NEWER = new Date("2026-09-09T14:16:32.520Z");
+
+    beforeEach(() => {
+      vi.mocked(parseTimestamp).mockImplementation((value) =>
+        value && typeof value === "object" && "datetime" in value
+          ? new Date(value.datetime)
+          : null,
+      );
+    });
+
+    it("prefers the recorded version when it is newer than the sample's", () => {
+      const stale = {
+        _id: "recorded-newer",
+        last_modified_at: { datetime: OLDER.getTime() },
+      } as Sample;
+      recordSampleVersionToken({
+        _id: "recorded-newer",
+        last_modified_at: { datetime: NEWER.getTime() },
+      });
+
+      expect(getSampleVersionToken({ sample: stale })).toBe(
+        "2026-09-09T14:16:32.520",
+      );
+    });
+
+    it("keeps the sample's version when it is newer than the recorded one", () => {
+      recordSampleVersionToken({
+        _id: "sample-newer",
+        last_modified_at: { datetime: OLDER.getTime() },
+      });
+      const fresh = {
+        _id: "sample-newer",
+        last_modified_at: { datetime: NEWER.getTime() },
+      } as Sample;
+
+      expect(getSampleVersionToken({ sample: fresh })).toBe(
+        "2026-09-09T14:16:32.520",
+      );
+    });
+
+    it("never regresses a recorded version to an older one", () => {
+      recordSampleVersionToken({
+        _id: "no-regress",
+        last_modified_at: { datetime: NEWER.getTime() },
+      });
+      recordSampleVersionToken({
+        _id: "no-regress",
+        last_modified_at: { datetime: OLDER.getTime() },
+      });
+      const stale = {
+        _id: "no-regress",
+        last_modified_at: { datetime: OLDER.getTime() },
+      } as Sample;
+
+      expect(getSampleVersionToken({ sample: stale })).toBe(
+        "2026-09-09T14:16:32.520",
+      );
+    });
+
+    it("ignores records without a usable id or timestamp", () => {
+      recordSampleVersionToken({ last_modified_at: { datetime: 1 } });
+      recordSampleVersionToken({ _id: "no-timestamp" });
+      recordSampleVersionToken(null);
+      const fresh = {
+        _id: "no-timestamp",
+        last_modified_at: { datetime: NEWER.getTime() },
+      } as Sample;
+
+      expect(getSampleVersionToken({ sample: fresh })).toBe(
+        "2026-09-09T14:16:32.520",
+      );
+    });
   });
 });

--- a/app/packages/annotation/src/util/getSampleVersionToken.ts
+++ b/app/packages/annotation/src/util/getSampleVersionToken.ts
@@ -56,20 +56,19 @@ export const getSampleVersionToken = ({
 }: {
   sample: Sample | null;
 }): string | null => {
-  if (!sample) {
+  if (!sample?.last_modified_at) {
     return null;
   }
 
-  const own = sample.last_modified_at
-    ? parseTimestamp(sample.last_modified_at)
-    : null;
-  const recorded = confirmed.get(sample._id);
+  const own = parseTimestamp(sample.last_modified_at);
 
-  if (own && recorded) {
-    return toToken(recorded.getTime() > own.getTime() ? recorded : own);
+  if (!own) {
+    return null;
   }
 
-  const latest = own ?? recorded;
+  const recorded = confirmed.get(sample._id);
 
-  return latest ? toToken(latest) : null;
+  return toToken(
+    recorded && recorded.getTime() > own.getTime() ? recorded : own,
+  );
 };

--- a/app/packages/annotation/src/util/getSampleVersionToken.ts
+++ b/app/packages/annotation/src/util/getSampleVersionToken.ts
@@ -2,10 +2,50 @@ import { parseTimestamp } from "@fiftyone/core/src/client/util";
 import type { Sample } from "@fiftyone/looker";
 
 /**
+ * Freshest server-confirmed `last_modified_at` per sample id, recorded from
+ * every write response. The modal sample a token is otherwise read from only
+ * catches up after an async refetch, so a second write inside that window
+ * would carry the pre-write token and fail the server's If-Match check.
+ */
+const confirmed = new Map<string, Date>();
+
+const toToken = (date: Date): string => {
+  const iso = date.toISOString();
+
+  // server doesn't like the iso timestamp ending in 'Z'
+  return iso.endsWith("Z") ? iso.substring(0, iso.length - 1) : iso;
+};
+
+/**
+ * Record a sample's server-confirmed version from a write response.
+ *
+ * @param sample Sample data as returned by the server
+ */
+export const recordSampleVersionToken = (
+  sample: Record<string, unknown> | null | undefined,
+): void => {
+  const id = sample?._id;
+  const date = parseTimestamp(
+    sample?.last_modified_at as Sample["last_modified_at"],
+  );
+
+  if (typeof id !== "string" || !date || Number.isNaN(date.getTime())) {
+    return;
+  }
+
+  const prior = confirmed.get(id);
+
+  if (!prior || date.getTime() > prior.getTime()) {
+    confirmed.set(id, date);
+  }
+};
+
+/**
  * Get a version token for a sample.
  *
  * A version token is a string which uniquely identifies a specific version of
- * a sample.
+ * a sample. The later of the sample's own `last_modified_at` and the version
+ * last confirmed by the server for that sample id wins.
  *
  * If a version token cannot be determined, `null` is returned instead.
  *
@@ -16,16 +56,20 @@ export const getSampleVersionToken = ({
 }: {
   sample: Sample | null;
 }): string | null => {
-  if (!sample?.last_modified_at) {
+  if (!sample) {
     return null;
   }
 
-  const isoTimestamp = parseTimestamp(sample.last_modified_at)?.toISOString();
+  const own = sample.last_modified_at
+    ? parseTimestamp(sample.last_modified_at)
+    : null;
+  const recorded = confirmed.get(sample._id);
 
-  // server doesn't like the iso timestamp ending in 'Z'
-  if (isoTimestamp?.endsWith("Z")) {
-    return isoTimestamp.substring(0, isoTimestamp.length - 1);
-  } else {
-    return isoTimestamp ?? null;
+  if (own && recorded) {
+    return toToken(recorded.getTime() > own.getTime() ? recorded : own);
   }
+
+  const latest = own ?? recorded;
+
+  return latest ? toToken(latest) : null;
 };

--- a/app/packages/annotation/src/util/labelPersistence.test.ts
+++ b/app/packages/annotation/src/util/labelPersistence.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@fiftyone/core/src/client", () => {
+  class VersionMismatchError extends Error {
+    constructor(
+      message?: string,
+      readonly responseBody?: Record<string, unknown>,
+      readonly versionToken?: string,
+    ) {
+      super(message);
+      this.name = "Version Mismatch Error";
+    }
+  }
+
+  return {
+    patchSample: vi.fn(),
+    transformSampleData: (sample: Record<string, unknown>) => sample,
+    VersionMismatchError,
+  };
+});
+
+vi.mock("@fiftyone/looker/src/util", () => ({
+  isSampleIsh: () => true,
+}));
+
+import { patchSample, VersionMismatchError } from "@fiftyone/core/src/client";
+import type { Sample } from "@fiftyone/looker";
+import { getSampleVersionToken } from "./getSampleVersionToken";
+import { doPatchSample } from "./labelPersistence";
+
+const LOADED = new Date("2026-09-09T14:16:24.457Z");
+const WRITTEN = new Date("2026-09-09T14:16:32.520Z");
+
+const serverSample = (id: string, lastModifiedAt: Date) => ({
+  _id: id,
+  _media_type: "image",
+  filepath: "/tmp/image.png",
+  last_modified_at: { datetime: lastModifiedAt.getTime() },
+});
+
+const makeArgs = (id: string) => {
+  const sample = serverSample(id, LOADED) as unknown as Sample;
+
+  return {
+    sample,
+    datasetId: "dataset-1",
+    getVersionToken: () => getSampleVersionToken({ sample }),
+    refreshSample: vi.fn(),
+    sampleDeltas: [{ op: "replace", path: "/label", value: "cat" }] as never,
+  };
+};
+
+describe("doPatchSample version token", () => {
+  beforeEach(() => {
+    vi.mocked(patchSample).mockReset();
+  });
+
+  it("sends the loaded token when nothing newer has been confirmed", async () => {
+    const args = makeArgs("first-write");
+    vi.mocked(patchSample).mockResolvedValue({
+      sample: serverSample("first-write", WRITTEN) as unknown as Sample,
+      versionToken: "etag",
+    });
+
+    await doPatchSample(args);
+
+    expect(patchSample).toHaveBeenCalledWith(
+      expect.objectContaining({ versionToken: "2026-09-09T14:16:24.457" }),
+    );
+  });
+
+  it("records the written version so the next write does not reuse the loaded token", async () => {
+    const args = makeArgs("second-write");
+    vi.mocked(patchSample).mockResolvedValue({
+      sample: serverSample("second-write", WRITTEN) as unknown as Sample,
+      versionToken: "etag",
+    });
+
+    await doPatchSample(args);
+    await doPatchSample(args);
+
+    expect(vi.mocked(patchSample).mock.calls[1][0].versionToken).toBe(
+      "2026-09-09T14:16:32.520",
+    );
+  });
+
+  it("records the server's version from a 412 body", async () => {
+    const args = makeArgs("mismatch");
+    vi.mocked(patchSample).mockRejectedValueOnce(
+      new VersionMismatchError(
+        "Invalid version token",
+        serverSample("mismatch", WRITTEN),
+        "etag",
+      ),
+    );
+
+    await expect(doPatchSample(args)).rejects.toBeInstanceOf(
+      VersionMismatchError,
+    );
+    expect(args.refreshSample).toHaveBeenCalledOnce();
+    expect(args.getVersionToken()).toBe("2026-09-09T14:16:32.520");
+  });
+});

--- a/app/packages/annotation/src/util/labelPersistence.ts
+++ b/app/packages/annotation/src/util/labelPersistence.ts
@@ -8,6 +8,7 @@ import type { Sample } from "@fiftyone/looker";
 import { NotFoundError } from "@fiftyone/utilities";
 import { isSampleIsh } from "@fiftyone/looker/src/util";
 import type { OpType } from "../types";
+import { recordSampleVersionToken } from "./getSampleVersionToken";
 
 export type DoPatchSampleArgs = {
   sample: Sample | null;
@@ -146,6 +147,7 @@ export const doPatchSample = async ({
       if (updatedSample) {
         // transform response data to match the graphql sample format
         const cleanedSample = transformSampleData(updatedSample);
+        recordSampleVersionToken(cleanedSample);
         postSample = cleanedSample;
         if (isSampleIsh(cleanedSample)) {
           refreshSample(cleanedSample as Sample);


### PR DESCRIPTION
## What / Why

Annotation writes carry an `If-Match` version token derived from the modal sample's `last_modified_at`. That sample only refreshes after an async graphql refetch, so two writes issued inside the refetch window both use the token from the initial load.

Concrete trace from the `segmentation-tool-snapshots.spec.ts:152` (merge) burn-in on #8405, which failed 1 of 10 repeats:

1. The merge's source delete flushes a PATCH immediately. It carries the union bounding box and the still-unencoded (old) mask. Server returns 200 with a fresh ETag.
2. 287 ms later the autosave tick sends the encoded merged mask in a second PATCH. It reuses the load-time token, so the server answers 412 "Version Mismatch Error: Invalid version token".
3. The 412 handler refreshes the modal sample from the server copy, which has the old filled mask stretched over the union box. The overlay repaints solid and the merged mask is lost.

With a 3 s autosave tick and a ~300 ms window this reproduces roughly one time in ten, which matches the burn-in result.

## How

`getSampleVersionToken` now keeps a per-sample record of the freshest `last_modified_at` the server has confirmed, populated by `doPatchSample` from every write response (including the sample body a 412 carries). The token is the later of the sample's own timestamp and that record, compared as timestamps. Nothing else about the CRDT flow changes; a genuinely concurrent edit still 412s and refreshes as before.

## Testing

- `yarn vitest run packages/annotation/src/util`: 2 files, 14 tests passed. New cases cover recorded-newer vs sample-newer precedence, no regression to an older record, ignoring malformed records, and `doPatchSample` recording the token from a 200 response and from a 412 body so the next write sends the updated token.
- `packages/annotation/src/hooks/usePatchSample.test.ts`: 8 passed.
- `tsc --noEmit -p packages/annotation/tsconfig.json`: no errors in the touched files (the package's pre-existing error count is unchanged).
- Integration evidence is the e2e burn-in of `oss/specs/segmentation-tool-snapshots.spec.ts:152` on #8405, which should pass all 10 repeats once this lands on main and is merged in.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4059
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved annotation saving by retaining the latest confirmed sample version.
  - Subsequent updates now use the most recent server-confirmed version, reducing stale-version conflicts.
  - Version information is refreshed after successful saves and handled appropriately when a version mismatch occurs.
  - Invalid, outdated, or regressing version records are ignored to prevent version state from moving backward.
  - Concurrent annotation saves are now coordinated to prevent overlapping writes and improve persistence reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->