### PR TITLE
Render sample-level classifications in video Explore mode

### DIFF
--- a/app/packages/video-annotation/src/components/RegisterVideoExploreLabels.test.tsx
+++ b/app/packages/video-annotation/src/components/RegisterVideoExploreLabels.test.tsx
@@ -12,10 +12,18 @@
  * degenerate pool view. Reordering these is silent at the type level and
  * produces empty overlays at runtime, so assert the sequence directly.
  *
- * SCOPE. The store and bridge must be driven by Explore's OWN active frame
- * fields. The annotation-schema defaults they otherwise fall back on are
- * populated only once the Annotate sidebar has loaded them, so in Explore
- * they are empty and nothing renders.
+ * SCOPE. The store and bridge must be driven by Explore's OWN active fields.
+ * The annotation-schema defaults they otherwise fall back on are populated
+ * only once the Annotate sidebar has loaded them, so in Explore they are
+ * empty and nothing renders. The bridge's scope is deliberately WIDER than
+ * the store's registration: it adds the sample-level classifications, whose
+ * omission is what kept the top-left bubble off this surface.
+ *
+ * SAMPLE HYDRATION. The shared `Sample` the composite store's
+ * `SampleLabelStore` half reads through is otherwise hydrated only by the
+ * Annotate sidebar, and an unhydrated one has an empty schema — so it
+ * enumerates no sample-level label at all. Explore has to mount that sync
+ * itself.
  */
 
 import { render } from "@testing-library/react";
@@ -24,7 +32,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const calls: string[] = [];
 
 const labelTypes = { "frames.detections": "Detections" };
-const paths = ["frames.detections"];
+const paths = ["frames.detections", "cls"];
+const sampleLevelPaths = ["cls"];
 
 vi.mock("../hooks/useSyncAnnotationFrameClock", () => ({
   useSyncAnnotationFrameClock: () => {
@@ -33,8 +42,9 @@ vi.mock("../hooks/useSyncAnnotationFrameClock", () => ({
 }));
 
 vi.mock("../hooks/useSyncAnnotationVideoStore", () => ({
-  useSyncAnnotationVideoStore: (arg: unknown) => {
-    calls.push(`store:${JSON.stringify(arg)}`);
+  useSyncAnnotationVideoStore: (labelTypesArg: unknown, options: unknown) => {
+    calls.push(`store:${JSON.stringify(labelTypesArg)}`);
+    calls.push(`storeOptions:${JSON.stringify(options)}`);
   },
 }));
 
@@ -46,7 +56,14 @@ vi.mock("../hooks/useVideoLighterEngineBridge", () => ({
 
 vi.mock("../state/exploreFrameLabelFields", () => ({
   useExploreFrameLabelFields: () => labelTypes,
-  useExploreFrameLabelPaths: () => paths,
+  useExploreOverlayPaths: () => paths,
+  useExploreSampleClassificationPaths: () => sampleLevelPaths,
+}));
+
+vi.mock("@fiftyone/annotation", () => ({
+  useSyncModalSample: () => {
+    calls.push("sample");
+  },
 }));
 
 import { RegisterVideoExploreLabels } from "./RegisterVideoExploreLabels";
@@ -60,18 +77,51 @@ describe("RegisterVideoExploreLabels", () => {
     render(<RegisterVideoExploreLabels />);
 
     expect(calls.map((c) => c.split(":")[0])).toEqual([
+      "sample",
       "clock",
       "store",
+      "storeOptions",
       "bridge",
     ]);
   });
 
-  it("scopes the store and the bridge to Explore's own frame fields", () => {
+  it("scopes the store and the bridge to Explore's own active fields", () => {
     render(<RegisterVideoExploreLabels />);
 
     // not the annotation-schema defaults, which are empty outside Annotate
     expect(calls).toContain(`store:${JSON.stringify(labelTypes)}`);
     expect(calls).toContain(`bridge:${JSON.stringify(paths)}`);
+  });
+
+  it("gives the bridge the sample-level classifications, not just frames.*", () => {
+    render(<RegisterVideoExploreLabels />);
+
+    // `bridgeLoop`'s `inScope` tests `paths.has(ref.path)`, so a frames-only
+    // scope drops every sample Classification before hydration — which is
+    // exactly how the top-left bubble went missing.
+    expect(calls).toContain(`bridge:${JSON.stringify(paths)}`);
+    expect(paths).toContain("cls");
+  });
+
+  it("hands the store the sample-level watch set for the hydration nudge", () => {
+    render(<RegisterVideoExploreLabels />);
+
+    // The nudge's own default is `useVisibleLabelSchemas()`, empty in Explore,
+    // so without an override `resync` never fires and a sample-level label
+    // that resolves its type after mount stays unmounted.
+    const store = calls.find((c) => c.startsWith("storeOptions:"));
+    expect(store).toBeDefined();
+    expect(store).toContain(
+      `"sampleLevelPaths":${JSON.stringify(sampleLevelPaths)}`,
+    );
+  });
+
+  it("hydrates the shared Sample, which only Annotate does otherwise", () => {
+    render(<RegisterVideoExploreLabels />);
+
+    // An unhydrated Sample has an empty schema, so `SampleLabelStore` finds no
+    // label paths and enumerates nothing sample-level at all.
+    expect(calls).toContain("sample");
   });
 
   it("renders nothing — it is a registrar, not a view", () => {

--- a/app/packages/video-annotation/src/components/RegisterVideoExploreLabels.tsx
+++ b/app/packages/video-annotation/src/components/RegisterVideoExploreLabels.tsx
@@ -3,12 +3,14 @@
  */
 
 import React from "react";
+import { useSyncModalSample } from "@fiftyone/annotation";
 import { useSyncAnnotationFrameClock } from "../hooks/useSyncAnnotationFrameClock";
 import { useSyncAnnotationVideoStore } from "../hooks/useSyncAnnotationVideoStore";
 import { useVideoLighterEngineBridge } from "../hooks/useVideoLighterEngineBridge";
 import {
   useExploreFrameLabelFields,
-  useExploreFrameLabelPaths,
+  useExploreOverlayPaths,
+  useExploreSampleClassificationPaths,
 } from "../state/exploreFrameLabelFields";
 
 /**
@@ -57,14 +59,34 @@ export const RegisterVideoExploreLabels: React.FC = () => {
   // populated once the Annotate sidebar (or the Schema Manager) has loaded
   // them, so in Explore they are empty and nothing would render.
   const labelTypes = useExploreFrameLabelFields();
-  const paths = useExploreFrameLabelPaths();
+  // The bridge's scope is WIDER than the store's registration: it adds the
+  // sample-level classification fields, which live on the composite store's
+  // `SampleLabelStore` half rather than the `FrameStore`, and which the
+  // frames-only scope used to filter out of hydration entirely.
+  const paths = useExploreOverlayPaths();
+  // The hydration nudge's watch set. Same reason as `paths`: its
+  // annotation-schema default is empty in Explore.
+  const sampleLevelPaths = useExploreSampleClassificationPaths();
 
+  // Hydrate the shared `Sample` (data + schema) that the composite store's
+  // `SampleLabelStore` half reads through. Only the Annotate sidebar mounts
+  // this otherwise, so in an Explore-only session the instance stayed empty:
+  // `SampleLabelStore.labelPaths()` walks `source.getSchema()`, an empty schema
+  // yields no label paths, and the store enumerated NOTHING sample-level — so
+  // the sample Classification was absent from `enumerateLabels` and from the
+  // temporal view's presence set long before scope or adapters came into it.
+  // The instance is shared and the hook is idempotent (it re-sets the same
+  // data/schema), so it is safe alongside Annotate's own mount.
+  useSyncModalSample();
   useSyncAnnotationFrameClock();
   // `seedWholeClip: false` — Explore is read-only, so nothing here walks the
   // whole clip, and the up-front fetch competes with the <video>'s own
   // buffering rather than helping it. The engine's `prefetch` window keeps
   // the store seeded around the playhead instead.
-  useSyncAnnotationVideoStore(labelTypes, { seedWholeClip: false });
+  useSyncAnnotationVideoStore(labelTypes, {
+    seedWholeClip: false,
+    sampleLevelPaths,
+  });
   // after the clock + store, so the bridge reconciles against the
   // FrameTemporalView and a seeded frame store
   useVideoLighterEngineBridge(paths);

--- a/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.test.tsx
+++ b/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2017-2026, Voxel51, Inc.
+ */
+
+/**
+ * The composite store's sample-level hydration nudge, and the override Explore
+ * needs to make it fire.
+ *
+ * `useHydrateSampleLevelOverlays` exists because the load-time consumers — the
+ * engine's Lighter bridge and the temporal view's presence cache — run once
+ * when the surface mounts, BEFORE the shared `Sample`'s schema has resolved a
+ * field's label type. While the type reads `Unknown` the field is excluded, and
+ * the `Sample` already being loaded, no later change re-fires them. `resync()`
+ * is the only thing that does.
+ *
+ * Its watch set defaulted to `useVisibleLabelSchemas()` — `annotation-active n
+ * explore-active` — which stays EMPTY until the Annotate sidebar has run
+ * `useLoadSchemas()`. So in an Explore-only session the signature never
+ * changed, `resync` was never called, and a sample Classification stayed
+ * unmounted even once the bridge's scope admitted it. These pin both halves:
+ * that an override makes the nudge fire, and that the bare default does not.
+ */
+
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted above every declaration in this file, so
+// everything they close over has to be hoisted with them.
+const h = vi.hoisted(() => {
+  const resync = vi.fn();
+  const dispose = vi.fn();
+  const unregisterStore = vi.fn();
+  const registerStore = vi.fn(() => unregisterStore);
+
+  /** Paths the engine is asked about, in order — the signature's real input. */
+  const listLabelsCalls: string[] = [];
+
+  /** What `useVisibleLabelSchemas()` returns; empty is Explore's reality. */
+  const state = { annotationVisible: [] as string[] };
+
+  class FakeFrameStore {
+    setData = vi.fn();
+    restore = vi.fn();
+    snapshot = vi.fn(() => ({}));
+    isDirty = vi.fn(() => false);
+  }
+
+  class FakeSampleLabelStore {
+    resync = resync;
+    dispose = dispose;
+  }
+
+  return {
+    resync,
+    dispose,
+    registerStore,
+    unregisterStore,
+    listLabelsCalls,
+    state,
+    FakeFrameStore,
+    FakeSampleLabelStore,
+  };
+});
+
+vi.mock("@fiftyone/annotation", () => ({
+  FrameStore: h.FakeFrameStore,
+  SampleLabelStore: h.FakeSampleLabelStore,
+  VideoLabelStore: class {},
+  useActiveSampleId: () => "sample-1",
+  useAnnotationEngine: () => ({ registerStore: h.registerStore }),
+  useSampleInstanceGetter: () => () => ({}),
+  // Run the selector for real against a stub `reads`, so the signature under
+  // test is the one the hook actually computes.
+  useEngineSelector: (_engine: unknown, selector: (reads: unknown) => string) =>
+    selector({
+      listLabels: ({ path }: { sample: string; path: string }) => {
+        h.listLabelsCalls.push(path);
+        return [{ _id: "label-1" }];
+      },
+      getLabelType: () => "Classification",
+    }),
+}));
+
+vi.mock("../streams/frameLabelsStream", () => ({
+  useFrameLabelsStream: () => ({
+    cachedFrames: () => [],
+    subscribeToEdits: () => () => undefined,
+    warmupAll: vi.fn(),
+  }),
+}));
+
+vi.mock("../streams/framesData", () => ({ parseFramesData: () => ({}) }));
+
+vi.mock("../state/accessors", () => ({
+  useFrameLabelFields: () => ({}),
+  useVisibleLabelSchemas: () => new Set(h.state.annotationVisible),
+}));
+
+import { useSyncAnnotationVideoStore } from "./useSyncAnnotationVideoStore";
+
+const Harness = ({
+  sampleLevelPaths,
+}: {
+  sampleLevelPaths?: ReadonlySet<string>;
+}) => {
+  useSyncAnnotationVideoStore({}, { seedWholeClip: false, sampleLevelPaths });
+  return null;
+};
+
+describe("useSyncAnnotationVideoStore sample-level hydration nudge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.listLabelsCalls.length = 0;
+    h.state.annotationVisible = [];
+  });
+
+  it("resyncs the sample-level backing when Explore supplies the paths", () => {
+    render(<Harness sampleLevelPaths={new Set(["cls"])} />);
+
+    // Without this the sample Classification never mounts: the bridge already
+    // ran its one reconcile while the type still read `Unknown`.
+    expect(h.resync).toHaveBeenCalled();
+  });
+
+  it("does NOT resync on the annotation default, which is empty in Explore", () => {
+    // The regression itself. `useVisibleLabelSchemas()` is empty until the
+    // Annotate sidebar loads the schemas, so the signature is "" and the
+    // effect bails — which is why the override exists.
+    render(<Harness />);
+
+    expect(h.resync).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the annotation set when no override is given", () => {
+    // Annotate's path must keep working: the override is additive, not a
+    // replacement of the default behavior.
+    h.state.annotationVisible = ["cls"];
+
+    render(<Harness />);
+
+    expect(h.resync).toHaveBeenCalled();
+  });
+
+  it("builds the signature from the override, not the annotation set", () => {
+    h.state.annotationVisible = ["ignored"];
+
+    render(<Harness sampleLevelPaths={new Set(["cls"])} />);
+
+    expect(h.listLabelsCalls).toContain("cls");
+    expect(h.listLabelsCalls).not.toContain("ignored");
+  });
+
+  it("leaves frame paths out of the signature", () => {
+    // The `FrameStore` dispatches its own changes via `setData`, so including
+    // `frames.*` here would re-announce them on every seed for nothing.
+    render(
+      <Harness sampleLevelPaths={new Set(["frames.detections", "cls"])} />,
+    );
+
+    expect(h.listLabelsCalls).toContain("cls");
+    expect(h.listLabelsCalls).not.toContain("frames.detections");
+  });
+
+  it("still registers the composite store when no field is active", () => {
+    // Visibility gates rendering, never the store: deactivating every field
+    // must not tear down the sample-level half and sweep its overlays.
+    render(<Harness sampleLevelPaths={new Set()} />);
+
+    expect(h.registerStore).toHaveBeenCalled();
+  });
+});

--- a/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
+++ b/app/packages/video-annotation/src/hooks/useSyncAnnotationVideoStore.ts
@@ -57,9 +57,23 @@ export const useSyncAnnotationVideoStore = (
      * what should be feeding this surface, and `warmupAll` competes with it.
      */
     seedWholeClip?: boolean;
+    /**
+     * Sample-level label paths the hydration nudge should watch (see
+     * {@link useHydrateSampleLevelOverlays}).
+     *
+     * Explore must supply its own. The default is `useVisibleLabelSchemas()`,
+     * which is `annotation-active ∩ explore-active` and therefore EMPTY until
+     * the Annotate sidebar has run `useLoadSchemas()` — so in Explore the
+     * signature never changes, `resync` never fires, and a sample-level label
+     * that resolves its type after the surface mounted stays unmounted. That
+     * is what kept the sample Classification bubble off this surface even once
+     * the bridge scope admitted it.
+     */
+    sampleLevelPaths?: ReadonlySet<string>;
   } = {},
 ): void => {
   const seedWholeClip = options.seedWholeClip ?? true;
+  const sampleLevelPathsOverride = options.sampleLevelPaths;
   const engine = useAnnotationEngine();
   const sampleId = useActiveSampleId();
   const getSample = useSampleInstanceGetter();
@@ -136,7 +150,12 @@ export const useSyncAnnotationVideoStore = (
     };
   }, [engine, sampleId, labelTypes, getSample, stream, seedWholeClip]);
 
-  useHydrateSampleLevelOverlays(engine, sampleId, sampleLevelRef);
+  useHydrateSampleLevelOverlays(
+    engine,
+    sampleId,
+    sampleLevelRef,
+    sampleLevelPathsOverride,
+  );
 };
 
 /**
@@ -166,8 +185,11 @@ const useHydrateSampleLevelOverlays = (
   engine: ReturnType<typeof useAnnotationEngine>,
   sampleId: string,
   sampleLevelRef: MutableRefObject<SampleLabelStore | null>,
+  pathsOverride?: ReadonlySet<string>,
 ): void => {
-  const visible = useVisibleLabelSchemas();
+  // Called unconditionally to keep hook order stable; the override wins.
+  const annotationVisible = useVisibleLabelSchemas();
+  const visible = pathsOverride ?? annotationVisible;
 
   // Sample-level label fields (exclude the frame fields — the FrameStore
   // announces those itself). TDs are kept in: resync refreshes the temporal

--- a/app/packages/video-annotation/src/state/accessors.ts
+++ b/app/packages/video-annotation/src/state/accessors.ts
@@ -9,11 +9,14 @@ import {
   fieldPaths,
   groupSlice,
   modalSampleId,
+  State,
   useCurrentDatasetId,
   view,
 } from "@fiftyone/state";
 import { FRAMES_PREFIX } from "@fiftyone/annotation";
 import {
+  CLASSIFICATION_FIELD,
+  CLASSIFICATIONS_FIELD,
   DETECTION,
   EMBEDDED_DOCUMENT_FIELD,
   LabelType,
@@ -72,6 +75,25 @@ export const useTemporalDetectionFieldPaths = () =>
     fieldPaths({
       ftype: EMBEDDED_DOCUMENT_FIELD,
       embeddedDocType: TEMPORAL_DETECTIONS_FIELD,
+    }),
+  );
+
+/**
+ * Schema paths of the dataset's SAMPLE-level classification fields, single and
+ * list alike.
+ *
+ * `space: SAMPLE` is what keeps the `frames.*` namespace out. A per-frame
+ * classification is the `FrameStore`'s to paint (see
+ * {@link useExploreFrameLabelFields}), and the composite `VideoLabelStore`
+ * routes by which half claims the path — admitting `frames.classifications`
+ * here would scope the same path twice, once per owner.
+ */
+export const useSampleClassificationFieldPaths = () =>
+  useRecoilValue(
+    fieldPaths({
+      space: State.SPACE.SAMPLE,
+      ftype: EMBEDDED_DOCUMENT_FIELD,
+      embeddedDocType: [CLASSIFICATION_FIELD, CLASSIFICATIONS_FIELD],
     }),
   );
 

--- a/app/packages/video-annotation/src/state/exploreFrameLabelFields.test.ts
+++ b/app/packages/video-annotation/src/state/exploreFrameLabelFields.test.ts
@@ -1,13 +1,26 @@
 /**
- * Which per-frame fields video Explore paints: `frames.*` only, resolved
- * against the frame schema, and narrowed to the types the frame projection
- * can actually seed.
+ * What video Explore paints, in both namespaces:
+ *
+ * - per-frame: `frames.*` only, resolved against the frame schema and
+ *   narrowed to the types the frame projection can actually seed;
+ * - sample-level: the classification fields the sidebar has active;
+ * - and the union of the two, which is the Lighter bridge's scope.
+ *
+ * The split matters. `bridgeLoop`'s `inScope` tests `paths.has(ref.path)`
+ * against that union, so a namespace missing from it is filtered out before
+ * hydration however plainly the sidebar has it checked — while the FrameStore's
+ * own registration must stay frames-only, because a sample-level label belongs
+ * to the composite store's `SampleLabelStore` half.
  */
 
 import { LabelType } from "@fiftyone/utilities";
 import { describe, expect, it } from "vitest";
 
-import { toExploreFrameLabelFields } from "./exploreFrameLabelFields";
+import {
+  toExploreFrameLabelFields,
+  toExploreOverlayPaths,
+  toExploreSampleClassificationPaths,
+} from "./exploreFrameLabelFields";
 
 const schema = (entries: Record<string, string>) =>
   Object.fromEntries(
@@ -92,5 +105,119 @@ describe("toExploreFrameLabelFields", () => {
     expect(
       toExploreFrameLabelFields([], schema({ detections: "Detections" })),
     ).toEqual({});
+  });
+});
+
+describe("toExploreSampleClassificationPaths", () => {
+  // The schema list comes from a `space: SAMPLE` query, so it is the authority
+  // on which paths are sample-level classifications; the active list is the
+  // authority on which the user wants to see.
+  it("keeps a sample classification the sidebar has active", () => {
+    expect([
+      ...toExploreSampleClassificationPaths(
+        ["cls", "frames.detections"],
+        ["cls"],
+      ),
+    ]).toEqual(["cls"]);
+  });
+
+  it("keeps every active classification field, single and list alike", () => {
+    expect([
+      ...toExploreSampleClassificationPaths(
+        ["cls", "predictions", "frames.detections"],
+        ["cls", "predictions"],
+      ),
+    ]).toEqual(["cls", "predictions"]);
+  });
+
+  it("drops a classification field the sidebar has not activated", () => {
+    // Visibility gates rendering: unchecking the field must clear its overlay.
+    expect([
+      ...toExploreSampleClassificationPaths(["frames.detections"], ["cls"]),
+    ]).toEqual([]);
+  });
+
+  it("drops an active path the schema does not call a classification", () => {
+    // Detections, temporal detections and primitives all reach `active`; only
+    // the schema can say which of them this scope may claim. A TD in
+    // particular must NOT appear — it renders through `useTemporalOverlaySync`
+    // and has no Lighter adapter, so scoping it here would be a silent no-op
+    // at best.
+    expect([
+      ...toExploreSampleClassificationPaths(
+        ["detections", "events", "filepath"],
+        ["cls"],
+      ),
+    ]).toEqual([]);
+  });
+
+  it("never claims a frame path, even one named in both lists", () => {
+    // `frames.classifications` is the FrameStore's to paint. The `space:
+    // SAMPLE` query keeps it out of the schema list in practice, so this pins
+    // the rule rather than relying on the query staying that way: every path
+    // has exactly one owning store, and admitting this one would hand it to
+    // both halves of the composite store.
+    expect([
+      ...toExploreSampleClassificationPaths(
+        ["frames.classifications"],
+        ["frames.classifications"],
+      ),
+    ]).toEqual([]);
+  });
+
+  it("returns nothing when the dataset has no classification field", () => {
+    expect([...toExploreSampleClassificationPaths(["cls"], [])]).toEqual([]);
+  });
+
+  it("returns nothing when no field is active", () => {
+    expect([...toExploreSampleClassificationPaths([], ["cls"])]).toEqual([]);
+  });
+});
+
+describe("toExploreOverlayPaths", () => {
+  it("unions both namespaces into the bridge's scope", () => {
+    expect([
+      ...toExploreOverlayPaths(
+        new Set(["frames.detections", "frames.classifications"]),
+        new Set(["cls"]),
+      ),
+    ]).toEqual(["frames.detections", "frames.classifications", "cls"]);
+  });
+
+  it("keeps the sample-level side — its omission was the original bug", () => {
+    const paths = toExploreOverlayPaths(
+      new Set(["frames.detections"]),
+      new Set(["cls"]),
+    );
+
+    expect(paths.has("cls")).toBe(true);
+  });
+
+  it("keeps the per-frame side", () => {
+    const paths = toExploreOverlayPaths(
+      new Set(["frames.detections"]),
+      new Set(["cls"]),
+    );
+
+    expect(paths.has("frames.detections")).toBe(true);
+  });
+
+  it("survives either side being empty", () => {
+    expect([
+      ...toExploreOverlayPaths(new Set(["frames.detections"]), new Set()),
+    ]).toEqual(["frames.detections"]);
+    expect([...toExploreOverlayPaths(new Set(), new Set(["cls"]))]).toEqual([
+      "cls",
+    ]);
+    expect([...toExploreOverlayPaths(new Set(), new Set())]).toEqual([]);
+  });
+
+  it("does not double-count a path both sides claim", () => {
+    expect([
+      ...toExploreOverlayPaths(
+        new Set(["frames.detections"]),
+        new Set(["frames.detections"]),
+      ),
+    ]).toEqual(["frames.detections"]);
   });
 });

--- a/app/packages/video-annotation/src/state/exploreFrameLabelFields.ts
+++ b/app/packages/video-annotation/src/state/exploreFrameLabelFields.ts
@@ -7,7 +7,10 @@ import * as fos from "@fiftyone/state";
 import { LabelType } from "@fiftyone/utilities";
 import { PROJECTABLE_FRAME_LABEL_TYPES } from "../streams/framesData";
 import { useMemo } from "react";
-import { useTemporalDetectionFieldPaths } from "./accessors";
+import {
+  useSampleClassificationFieldPaths,
+  useTemporalDetectionFieldPaths,
+} from "./accessors";
 
 /**
  * Label types the per-frame pipeline can actually paint.
@@ -99,6 +102,62 @@ export const useExploreFrameLabelFields = (): Record<string, LabelType> => {
 export const useExploreFrameLabelPaths = (): ReadonlySet<string> => {
   const fields = useExploreFrameLabelFields();
   return useMemo(() => new Set(Object.keys(fields)), [fields]);
+};
+
+/**
+ * The SAMPLE-level classification fields Explore should paint.
+ *
+ * A sample Classification is not `frames.*`, so {@link useExploreFrameLabelPaths}
+ * — which exists to keep the per-frame namespace the `FrameStore` owns — can
+ * never answer for it, and the bridge scope built from that hook alone silently
+ * dropped every sample classification: `bridgeLoop`'s `inScope` tests
+ * `paths.has(ref.path)`, so `cls` was filtered out before hydration however
+ * plainly the sidebar had it checked. That is the whole reason the top-left
+ * bubble the video looker drew went missing on this surface.
+ *
+ * Nothing else in the pipeline needed changing: `FrameTemporalView` already
+ * reports a sample-level label as present on every frame (only a temporal
+ * detection is gated by its `support`), `SampleLabelStore` resolves the type
+ * from the sample's own schema rather than the annotation schemas, and
+ * `classificationAdapter` is registered for both Classification and
+ * Classifications. Scope was the only gate.
+ *
+ * Derived from the sidebar's active paths for the same reason the per-frame
+ * hook is: the annotation-schema sets stay empty in Explore until the Annotate
+ * sidebar has loaded them.
+ */
+export const useExploreSampleClassificationPaths = (): ReadonlySet<string> => {
+  const active = fos.useActiveFields({ modal: true });
+  const classificationFields = useSampleClassificationFieldPaths();
+
+  return useMemo(() => {
+    const known = new Set(classificationFields);
+    return new Set(active.filter((path) => known.has(path)));
+  }, [active, classificationFields]);
+};
+
+/**
+ * Everything the Explore surface's Lighter bridge should hydrate: the paintable
+ * per-frame fields plus the sample-level classifications.
+ *
+ * The bridge takes ONE flat scope regardless of a path's temporal posture —
+ * `frameOf` is what stamps the playhead frame onto `frames.*` and leaves a
+ * sample-level path frame-less — so both namespaces belong in the same set.
+ * The frame store's own registration stays frames-only
+ * ({@link useExploreFrameLabelFields}): a sample classification is the
+ * `SampleLabelStore` half's to hold.
+ *
+ * Temporal detections are deliberately absent — they render through
+ * `useTemporalOverlaySync`, not the bridge, and carry no Lighter adapter.
+ */
+export const useExploreOverlayPaths = (): ReadonlySet<string> => {
+  const framePaths = useExploreFrameLabelPaths();
+  const classificationPaths = useExploreSampleClassificationPaths();
+
+  return useMemo(
+    () => new Set([...framePaths, ...classificationPaths]),
+    [framePaths, classificationPaths],
+  );
 };
 
 /**

--- a/app/packages/video-annotation/src/state/exploreFrameLabelFields.ts
+++ b/app/packages/video-annotation/src/state/exploreFrameLabelFields.ts
@@ -130,10 +130,46 @@ export const useExploreSampleClassificationPaths = (): ReadonlySet<string> => {
   const active = fos.useActiveFields({ modal: true });
   const classificationFields = useSampleClassificationFieldPaths();
 
-  return useMemo(() => {
-    const known = new Set(classificationFields);
-    return new Set(active.filter((path) => known.has(path)));
-  }, [active, classificationFields]);
+  return useMemo(
+    () => toExploreSampleClassificationPaths(active, classificationFields),
+    [active, classificationFields],
+  );
+};
+
+/**
+ * Pure half of {@link useExploreSampleClassificationPaths}: sidebar active
+ * paths plus the schema's sample-level classification paths in, the paths
+ * Explore should paint out. Separated from the hook for the same reason
+ * {@link toExploreFrameLabelFields} is — the selection rule is testable
+ * without a state provider.
+ *
+ * The schema list is the authority on WHICH paths are sample-level
+ * classifications (it comes from a `space: SAMPLE` query, so `frames.*` is
+ * already absent); the active list is the authority on which of them the user
+ * is asking to see. Intersecting is what keeps a checked-but-nonexistent path
+ * and an existing-but-unchecked one both out.
+ *
+ * @param active - Sidebar active paths, `frames.`-prefixed for frame fields.
+ * @param classificationFields - Sample-level classification paths in the
+ *   dataset schema.
+ */
+export const toExploreSampleClassificationPaths = (
+  active: readonly string[],
+  classificationFields: readonly string[],
+): ReadonlySet<string> => {
+  const known = new Set(classificationFields);
+
+  return new Set(
+    active.filter(
+      // The `frames.` exclusion is belt-and-braces: a `space: SAMPLE` query
+      // cannot return a frame path today. It is asserted rather than assumed
+      // because every path in the engine has exactly one owning store, and
+      // `frames.classifications` belongs to the `FrameStore` — if the query
+      // ever widened, an unguarded intersection would hand one path to both
+      // halves of the composite store.
+      (path) => !path.startsWith(FRAMES_PREFIX) && known.has(path),
+    ),
+  );
 };
 
 /**
@@ -155,10 +191,20 @@ export const useExploreOverlayPaths = (): ReadonlySet<string> => {
   const classificationPaths = useExploreSampleClassificationPaths();
 
   return useMemo(
-    () => new Set([...framePaths, ...classificationPaths]),
+    () => toExploreOverlayPaths(framePaths, classificationPaths),
     [framePaths, classificationPaths],
   );
 };
+
+/**
+ * Pure half of {@link useExploreOverlayPaths}. A union, but a load-bearing
+ * one — dropping either side is how an entire label namespace stops painting,
+ * and neither omission fails at the type level.
+ */
+export const toExploreOverlayPaths = (
+  framePaths: ReadonlySet<string>,
+  classificationPaths: ReadonlySet<string>,
+): ReadonlySet<string> => new Set([...framePaths, ...classificationPaths]);
 
 /**
  * The sample-level TemporalDetections fields Explore should paint.


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link. Reported by Eric in Slack against `release.rc`
(`quickstart-video`, `cls` field) ahead of the release.

## 📋 What changes are proposed in this pull request?

The top-left classification bubble the video looker drew was missing on the
video **Explore** surface for **sample-level** classification fields.

Frame-level classifications (`frames.classifications`) already work on current
`main` — verified in the app on a video sample carrying both. Only sample-level
was broken, and three independent gates dropped it, in sequence:

1. **Bridge scope.** The Explore bridge's projection scope came from
   `useExploreFrameLabelPaths`, which exists to hold the `frames.*` namespace
   and so can never name `cls`. `bridgeLoop`'s `inScope` tests
   `paths.has(ref.path)`, so the field was filtered out before hydration
   however plainly the sidebar had it checked.

2. **The shared `Sample` was never hydrated.** `useSyncModalSample()` is
   mounted only by the Annotate sidebar. In an Explore-only session the
   instance stayed empty, and `SampleLabelStore.labelPaths()` walks
   `source.getSchema()` — an empty schema yields no label paths, so the store
   enumerated *nothing* sample-level. `cls` was absent from `enumerateLabels`
   and from the temporal view's presence set long before scope or adapters came
   into it.

3. **The hydration nudge never fired.** `useHydrateSampleLevelOverlays` exists
   to mount a sample-level label whose type resolves *after* the surface
   mounted, but it watches `useVisibleLabelSchemas()` — `annotation-active ∩
   explore-active`, which stays empty until Annotate has run
   `useLoadSchemas()`. In Explore its signature never changed, so `resync` was
   never called.

Each fix mirrors the existing per-frame one: read the sidebar's own active
paths rather than the annotation schemas, which are only populated once the
Annotate sidebar has loaded them.

Nothing in the engine needed changing. `FrameTemporalView` already reports a
sample-level label as present on every frame (only a temporal detection is
gated by its `support`), `SampleLabelStore` resolves the type from the sample's
own schema, and `classificationAdapter` is already registered for both
`Classification` and `Classifications`.

Temporal detections are deliberately left out of the widened scope — they
render through `useTemporalOverlaySync`, not the bridge, and carry no Lighter
adapter.

### Note on `useSyncModalSample` in Explore

The two surfaces are mutually exclusive — `ModalLooker` renders
`isAnnotate ? <VideoAnnotationSurface> : <VideoTimelineSurface>` — so exactly
one of them mounts the hook at a time. The hook re-sets the same data and
schema on mount, so the incoming owner re-hydrates across a mode switch.

## 🧪 How is this patch tested? If it is not, please explain why.

**Manual, in the app** — this is a cross-subsystem state bug, so green unit
tests alone would not have proved it. Built a local video dataset carrying both
a sample-level `cls` Classification and per-frame `frames.classifications`,
opened the Explore modal, and instrumented `bridgeLoop`, `FrameTemporalView`
and `SampleLabelStore` to confirm each gate in turn:

- before: `SampleLabelStore` reported `schemaKeys: []`, `labelPaths: []`, and
  the bridge mounted only the two `frames.*` refs;
- after: `cls=Classification` resolves, the ref appears in the temporal view's
  present set as `cls#…@undefined` (frame-less, as intended), and the overlay
  mounts.

Visually confirmed both bubbles paint, correctly stacked in the top-left
(`frame-cls 0.5` above `sample-level-cls 0.9`). All instrumentation was
reverted before committing.

**Unit tests** — each of the three fixes is independently load-bearing and
none fails at the type level, so each has a test that goes red when the fix is
reverted. Verified by mutating the source in place and watching them fail:

| Mutation | Tests that fail |
|---|---|
| bridge scope back to `useExploreFrameLabelPaths` | 6 in `RegisterVideoExploreLabels.test.tsx` |
| drop `useSyncModalSample()` | 2 in `RegisterVideoExploreLabels.test.tsx` |
| ignore `sampleLevelPaths` in the nudge | 3 in `useSyncAnnotationVideoStore.test.tsx` |

The selection rules are tested as pure functions, following the
`toExploreFrameLabelFields` precedent in the same file:

- `toExploreSampleClassificationPaths` — an unchecked field is dropped
  (visibility gates rendering), a non-classification active path is not
  claimed (temporal detections especially, since they render through
  `useTemporalOverlaySync` and have no Lighter adapter), and a `frames.` path
  is never claimed. That last rule is now *enforced* rather than incidental:
  a `space: SAMPLE` query cannot return a frame path today, but every path has
  exactly one owning store, and an unguarded intersection would hand
  `frames.classifications` to both halves of the composite store if the query
  ever widened.
- `toExploreOverlayPaths` — the union that is the bridge's scope. A one-liner,
  but dropping either side silently stops a whole namespace painting.

`useSyncAnnotationVideoStore.test.tsx` is new. It runs the signature selector
for real against a stub `reads`, so the string under test is the one the hook
computes, and pins that an override makes `resync` fire, that frame paths stay
out of the signature (the `FrameStore` announces its own), that Annotate's
default path still works, and — the regression itself — that the bare
`useVisibleLabelSchemas()` default does *not* resync.

`955 passed | 3 skipped` across `packages/video-annotation` and
`packages/annotation`. ESLint clean; prettier 3.8.5 (the CI version) reports
all changed files formatted.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

Sample-level classification fields now render as a bubble in the top-left of
the canvas in video Explore mode, matching the previous video looker's
behavior. Frame-level classifications were already rendering.

### What areas of FiftyOne does this PR affect?

- [x] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explore now supports sample-level classification labels alongside frame-level labels.
  - Active Explore overlays include eligible sample classifications while excluding temporal detections.
  - Sample-level classifications are synchronized and hydrated in the video annotation experience.

- **Bug Fixes**
  - Improved Explore label synchronization when sidebar schemas have not yet loaded.
  - Ensured shared sample data is populated consistently for Explore annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4066
<!-- enterprise-sync-pr:end -->