### PR TITLE
Docs: spatiotemporal comments in the Enterprise App guide (FOEPD-4332)

### DIFF
--- a/docs/source/enterprise/app.rst
+++ b/docs/source/enterprise/app.rst
@@ -167,6 +167,31 @@ comments on samples that need work while reviewing labels.
 .. image:: https://cdn.voxel51.com/enterprise/app/comments.webp
    :alt: Discussion panel with a comment thread on a sample
 
+.. _enterprise-spatiotemporal-comments:
+
+Spatiotemporal comments
+-----------------------
+
+.. customavailablein::
+    :enterprise_version: 2.25.0
+
+Comments can also be anchored to a point or region on the media itself.
+Click the pin button in the Discussion panel header, then click the sample
+to place a point or drag to mark a region. Each anchor appears as a numbered
+marker on the media. Click a marker to open its thread. Anchors are fixed
+once posted. To move one, delete the comment and place it again.
+
+On videos, an anchor is tied to the current frame. On
+:ref:`grouped datasets <groups>`, it is tied to the current slice. On
+:ref:`multimodal <fiftyone-multimodal>` episodes, it is tied to a tile's
+stream and timestamp. The marker appears only when that frame, slice, or
+timestamp is displayed. The comment's chip in the Discussion panel takes you
+back to it. The video timeline marks every commented frame. Point cloud
+tiles are not supported.
+
+.. image:: https://cdn.voxel51.com/enterprise/app/comments_spatiotemporal.webp
+   :alt: Anchored comments on a video frame, marked on the timeline and listed in the Discussion panel
+
 .. _enterprise-managing-datasets:
 
 Managing a dataset


### PR DESCRIPTION
## 🔗 Related Issues

No GitHub issues to link — Jira: [FOEPD-4332](https://voxel51.atlassian.net/browse/FOEPD-4332). Supersedes voxel51/fiftyone-teams#4072, which targeted the wrong repo (docs go to `fiftyone`, per #docs).

## 📋 What changes are proposed in this pull request?

Adds a **Spatiotemporal comments** section to the Enterprise App guide (`docs/source/enterprise/app.rst`), directly after the existing **Comments** section, documenting the feature that shipped in voxel51/fiftyone-teams#3970: anchoring a comment to a point or region on the media, how anchors scope to a video frame, group slice, or multimodal tile timestamp, the timeline markers, the Discussion panel chip that takes you back to the anchor, and that anchors are fixed once posted.

Kept to the scale of the surrounding sections: two short paragraphs and one screenshot. The image is hosted on the CDN at `enterprise/app/comments_spatiotemporal.webp`:

![Anchored comments on a video frame, marked on the timeline and listed in the Discussion panel](https://cdn.voxel51.com/enterprise/app/comments_spatiotemporal.webp)

**Open question for review:** the `customavailablein` marker says `2.25.0`. Enterprise `main` was on 2.25.0-dev when the feature merged on Sept 4 and advanced to 2.26.0-dev on Sept 7, so 2.25.0 looks right, but please confirm against the actual release cut.

## 🧪 How is this patch tested? If it is not, please explain why.

Docs-only change. Checked the RST structure (heading underline lengths, and that the `:ref:` targets `groups` and `fiftyone-multimodal` exist) and that the CDN image URL returns 200 with `image/webp`. Not built locally.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

N/A

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [x] Documentation: FiftyOne documentation changes
- [ ] Other


[FOEPD-4332]: https://voxel51.atlassian.net/browse/FOEPD-4332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using spatiotemporal comments in the FiftyOne Enterprise App.
  - Documented comment anchoring to points, regions, and timeline markers across supported video, grouped dataset, and multimodal episode workflows.
  - Clarified behavior for unsupported point-cloud tiles.
  - Noted availability beginning with Enterprise version 2.25.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4074
<!-- enterprise-sync-pr:end -->