### PR TITLE
ci: own the oss-merged-check job in pr.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -147,6 +147,29 @@ jobs:
       needs.modified-files.outputs.format-changes == 'true')
     uses: ./.github/workflows/lint-app.yml
 
+  oss-merged-check:
+    # Downstream repos gate merges on an `oss / merged` status that their sync
+    # workflows post for oss-sync/* PRs. Native PRs there have no OSS
+    # counterpart, so this auto-passes the status for them. Skipped here.
+    if: >-
+      github.repository != 'voxel51/fiftyone' &&
+      !startsWith(github.head_ref, 'oss-sync/')
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'success',
+              context: 'oss / merged',
+              description: 'Not an OSS sync PR',
+            });
+
   lint-python:
     needs: modified-files
     if: >-


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

Downstream repos gate merges on an `oss / merged` status that their sync workflows post for `oss-sync/*` PRs. Native PRs there have no OSS counterpart, so a small `oss-merged-check` job auto-passes the status for them. That job existed only in the downstream copy of `pr.yml`, so it drifted from this file and still pinned `actions/github-script@v7`, a Node 20 action that runners now flag on every run.

This defines the job here, gated on `github.repository != 'voxel51/fiftyone'`, at `actions/github-script@v9`. In this repo it is always skipped: it is not in the `all-tests` or `ci-comment` `needs`, and `suite-rows.mjs` already ignores it. Downstream, the sync brings the shared definition in and the remaining Node 20 pins in downstream-only workflows are bumped on the sync companion.

## 🧪 How is this patch tested? If it is not, please explain why.

YAML parses. The job is skipped on this PR's own run. The sync companion exercises the job on its first native PR downstream.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [x] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated commit status reporting for qualifying pull requests in non-upstream repositories.
  * Excluded upstream repository pull requests and OSS synchronization branches from this status check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4078
<!-- enterprise-sync-pr:end -->