### PR TITLE
e2e: prefix temp script names so they can never shadow a Python module

### DIFF
--- a/e2e-pw/src/oss/utils/fs.ts
+++ b/e2e-pw/src/oss/utils/fs.ts
@@ -1,9 +1,10 @@
+import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
 
 export function writeToTmpFile(content: string, extension: string): string {
-  const randomFileName = `fo-e2e-${Math.random().toString(36).substring(8)}`;
+  const randomFileName = `fo-e2e-${crypto.randomUUID()}`;
   const sourceFilePath = path.join(
     os.tmpdir(),
     `${randomFileName}.${extension}`,

--- a/e2e-pw/src/oss/utils/fs.ts
+++ b/e2e-pw/src/oss/utils/fs.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path from "path";
 
 export function writeToTmpFile(content: string, extension: string): string {
-  const randomFileName = Math.random().toString(36).substring(8);
+  const randomFileName = `fo-e2e-${Math.random().toString(36).substring(8)}`;
   const sourceFilePath = path.join(
     os.tmpdir(),
     `${randomFileName}.${extension}`,


### PR DESCRIPTION
## What changes

`writeToTmpFile` named e2e fixture scripts with the bare tail of `Math.random().toString(36).substring(8)`, which is only 3 to 5 base36 characters. The name is now `fo-e2e-<uuid>`.

## Why

A CI run produced `/tmp/csv.py`. Python puts the script's directory on `sys.path`, so every later `import fiftyone` in that worker resolved the stdlib `csv` module to that fixture script, which itself imports fiftyone, and the import went circular:

```
  File "/usr/local/lib/python3.10/importlib/metadata/__init__.py", line 4, in <module>
    import csv
  File "/tmp/csv.py", line 2, in <module>
    import fiftyone.utils.utils3d as fou3d
  ...
AttributeError: module 'importlib' has no attribute 'metadata'
Error: Python process exited with code 1
```

Seven unrelated specs failed at 0.0s on both attempts because the stray file stayed in the temp dir for the rest of the shard.

Two problems with the old name:

- **Module shadowing.** `import fiftyone` loads about 225 top-level modules the generator could spell (`csv`, `json`, `enum`, `math`, `numpy`, `scipy`, ...). Weighted by the generator's length distribution that is about 1 in 500 CI runs. The `fo-e2e-` prefix contains a hyphen, so the basename can never be a valid Python identifier.
- **Self-collision.** The files are never deleted, so a shard's scripts draw against each other. With 3 to 5 characters that is the same order of magnitude. A UUID removes it.

## How I tested

Sampled the generator in Node to get the tail-length distribution (3 chars 0.75%, 4 chars 26%, 5 chars 70%) and the per-call collision rate against the real `import fiftyone` module set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary files generated during end-to-end testing now use a consistent `fo-e2e-` filename prefix.
  * Generated temporary filenames are now uniquely identified using UUID-based naming, reducing the likelihood of filename collisions during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4085
<!-- enterprise-sync-pr:end -->