### PR TITLE
Bump fiftyone-brain to 0.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "scikit-image<1",
         "scipy<2",
         # internal packages
-        "fiftyone-brain>=0.24.0,<0.25",
+        "fiftyone-brain>=0.25.0,<0.26",
         "fiftyone-db>=0.4,<2.0",
         "voxel51-eta>=0.17,<0.18",
     ],


### PR DESCRIPTION
Pins `fiftyone-brain>=0.25.0,<0.26`.

fiftyone-brain 0.25.0 adds IVFFlat indexes and `halfvec` storage to the pgvector backend (voxel51/fiftyone-brain#311, #312, #314). Draft until 0.25.0 is on PyPI (release PR voxel51/fiftyone-brain#319).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported `fiftyone-brain` version range to the 0.25 release series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4099
<!-- enterprise-sync-pr:end -->