### PR TITLE
Fix lerobot webcodec

### DIFF
--- a/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.test.ts
@@ -459,6 +459,47 @@ describe("WebCodecsVideoDecoder AV1", () => {
   });
 });
 
+describe("WebCodecsVideoDecoder H.264 parameter sets", () => {
+  const SPS = Uint8Array.of(0x67, 0x4d, 0, 0x1f);
+  const PPS = Uint8Array.of(0x68, 0xce);
+  const START_CODE = Uint8Array.of(0, 0, 0, 1);
+  const inlined = (slice: Uint8Array) =>
+    Uint8Array.from([...START_CODE, ...SPS, ...START_CODE, ...PPS, ...slice]);
+
+  it.each([
+    {
+      name: "a keyframe",
+      slice: Uint8Array.of(0, 0, 1, 0x65),
+      targetTimeNs: 0n,
+      units: [unit(0, true)],
+    },
+    {
+      name: "a delta frame",
+      slice: Uint8Array.of(0, 0, 1, 0x41),
+      targetTimeNs: 1n,
+      units: [unit(0, true), unit(1)],
+    },
+  ])(
+    "inlines the container's parameter sets ahead of $name whose bytes carry none",
+    async ({ slice, targetTimeNs, units }) => {
+      const harness = fakeWebCodecs();
+      const actor = new WebCodecsVideoDecoder(harness.environment);
+
+      const output = await actor.decode(units, {
+        signal: new AbortController().signal,
+        targetTimeNs,
+      });
+
+      const submitted = harness.instances[0].decode.mock.calls.at(-1)?.[0] as {
+        readonly data: Uint8Array;
+      };
+      expect(submitted.data).toEqual(inlined(slice));
+      output.close();
+      actor.close();
+    },
+  );
+});
+
 function fakeWebCodecs(
   options: {
     readonly deferOutputs?: boolean;

--- a/app/packages/multimodal/src/video/webcodecs-decoder.ts
+++ b/app/packages/multimodal/src/video/webcodecs-decoder.ts
@@ -574,10 +574,13 @@ export class WebCodecsVideoDecoder implements VideoDecoderActor {
     if (unit.frame.codec !== "h264") return unit.frame.bytes;
     if (unit.frame.h264.sps) this.sps = unit.frame.h264.sps;
     if (unit.frame.h264.pps) this.pps = unit.frame.h264.pps;
+    // A frame's parameter sets come from the container's out-of-band record
+    // (avcC), so the access unit still needs them inlined; a stream that also
+    // carries them in-band decodes fine with the repeat
     return h264AccessUnitWithParameterSets({
       bytes: unit.frame.bytes,
-      pps: unit.frame.h264.pps ? undefined : this.pps,
-      sps: unit.frame.h264.sps ? undefined : this.sps,
+      pps: this.pps,
+      sps: this.sps,
     });
   }
 }


### PR DESCRIPTION
<!--
Community contributors: target the `community` branch, not `main`. PRs from
non-members are auto-retargeted to `community`. See CONTRIBUTING.md:
https://github.com/voxel51/fiftyone/blob/main/CONTRIBUTING.md#community-pull-requests
-->

## 🔗 Related Issues

- Lerobot dataset loads with black grid tiles until hover and modal video never renders
<img width="1914" height="1084" alt="image" src="https://github.com/user-attachments/assets/2d6d275e-0d84-41ba-a371-f40bbb654877" />

## 📋 What changes are proposed in this pull request?

- inline avcC SPS/PPS on every H.264 access unit

## 🧪 How is this patch tested? If it is not, please explain why.


https://github.com/user-attachments/assets/d099a399-5150-4a34-ac00-4262e1c6af6a



## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

<!--
If answering "yes" above:
Details in 1-2 sentences. You can refer to another PR with a description
if this PR is part of a larger change.

If answering "no" above, leave empty or add "N/A"
-->

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [ ] Core: Core `fiftyone` Python library changes
- [ ] Documentation: FiftyOne documentation changes
- [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved H.264 video decoding by consistently applying required parameter sets to video frames, including frames that already contain embedded configuration data.
  * Prevented decoding issues for keyframes and delta frames missing inline parameter sets.

* **Tests**
  * Added coverage for H.264 parameter-set handling across keyframes and delta frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4095
<!-- enterprise-sync-pr:end -->