### PR TITLE
CI comment: python section from the latest attempt's junit

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -225,14 +225,17 @@ jobs:
         # python matrix was skipped or died before uploading
         run: |
           mkdir -p pytest-junit
-          gh api --paginate \
-            "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
-            --jq '.artifacts[] | select(.name | startswith("pytest-results-")) | [.id, .name] | @tsv' |
+          # reruns list every attempt's artifact under the same name; keep
+          # only the newest per name so a rerun's results replace the
+          # earlier attempt's instead of being overwritten by them
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" |
+          jq -r '[.[].artifacts[] | select(.name | startswith("pytest-results-"))]
+                 | group_by(.name) | map(max_by(.created_at))[]
+                 | [.id, .name] | @tsv' |
           while IFS=$'\t' read -r id name; do
             gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$id/zip" > "$name.zip"
-            # -o: reruns list every attempt's artifact under the same name;
-            # an interactive replace prompt would fail the job
-            unzip -o -q -d "pytest-junit/$name" "$name.zip"
+            unzip -q -d "pytest-junit/$name" "$name.zip"
             printf '%s\t%s\n' "$name" \
               "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts/$id" \
               >> pytest-junit/artifact-urls.tsv


### PR DESCRIPTION
## 📋 What changes are proposed in this pull request?

After a rerun, the CI comment's python section kept reporting failures the rerun had fixed (e.g. #8437: header and suite table green, python line "❌ 1 failed" with the attempt-1 `tests.isolated.service_tests` error and junit links pointing at the attempt-1 artifacts).

Cause: reruns leave every attempt's `pytest-results-*` artifact on the run under the same name. The download step fetched all of them and unzipped each into the same directory with `-o`; the API lists newest first, so the earlier attempt's junit overwrote the rerun's.

Fix: keep only the newest artifact per name (`group_by(.name) | map(max_by(.created_at))`) before downloading. `unzip -o` is no longer needed since there is one artifact per name. The artifact links in the comment become correct after a rerun as well.

## 🧪 How is this patch tested? If it is not, please explain why.

The jq was run against run 34511743293's real artifact list and selects exactly the two attempt-2 artifacts. Workflow YAML parses. The behaviour itself only shows on a rerun of this PR's own CI.

## 📝 Release Notes

- [x] No. CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4101
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test result artifact handling to use only the newest artifact for each name.
  * Prevented rerun artifacts from overwriting newer test results.
  * Replaced interactive overwrite prompts with consistent automatic handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->