### PR TITLE
ci(renovate): stop bundling npm minors into one PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,8 +39,18 @@
         },
         {
             "matchManagers": ["npm"],
-            "groupName": "app-dependencies",
             "addLabels": ["app"]
+        },
+        {
+            "matchManagers": ["npm"],
+            "matchUpdateTypes": ["patch", "pin", "digest"],
+            "groupName": "app-dependencies"
+        },
+        {
+            "matchManagers": ["npm"],
+            "matchUpdateTypes": ["minor"],
+            "matchCurrentVersion": "<1.0.0",
+            "enabled": false
         },
         {
             "matchManagers": ["github-actions"],


### PR DESCRIPTION
The npm rule grouped every update into a single `app-dependencies` PR. #8231 is what that produces: 20 bumps in one PR, including react 18.2→18.3, `@voxel51/voodo` 0.1→0.2, three 0.182→0.186, typedoc 0.23→0.28, prettier 3.8→3.9, and yarn 4.17→4.18. The `major` filter never catches the 0.x bumps.

After this change:

- patch, pin, and digest updates stay grouped in `app-dependencies`
- each minor bump gets its own PR
- minor bumps on 0.x packages are skipped, the same as majors already are

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4112
<!-- enterprise-sync-pr:end -->