### PR TITLE
Add the Hilti SLAM Challenge 2021 dataset to the dataset zoo

### DIFF
--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -3726,6 +3726,85 @@ class RoboLabDataset(FiftyOneDataset):
         return dataset_type, num_samples, None
 
 
+class HiltiSLAMChallenge2021Dataset(FiftyOneDataset):
+    """The Hilti SLAM Challenge 2021 recordings, as native ``.mcap``
+    episodes.
+
+    The first of the Hilti challenges and the one with the densest sensor
+    suite. Twelve sequences were walked through offices, a lab, basements,
+    a parking deck, campuses and construction sites, chosen for the things
+    that break a SLAM system in the field: bare corridors with almost no
+    geometric or visual structure, illumination that changes as the
+    operator moves between floors and outdoors, stairs, and long loops.
+
+    The rig is a surveying pole carrying a Sevensense Alphasense head with
+    five global-shutter cameras at 1440x1080 and an inertial unit, an
+    Ouster OS0-64 spinning LiDAR, a Livox MID70 solid-state LiDAR and an
+    ADIS16445 inertial unit. Every sensor's clock agrees to within a
+    millisecond. Both LiDARs and all five cameras run at 10 Hz, so every
+    visual and 3D stream in an episode shares one clock.
+
+    Ten sequences carry sparse 3-DoF reference positions measured with a
+    total station while the rig was held still, and two carry a continuous
+    6-DoF trajectory from an Optitrack motion-capture system. Both are
+    timed, and every episode carries the reference at the instants the
+    release measured it along with the rig's calibrated frame tree.
+
+    Example usage::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("hilti-slam-challenge-2021")
+
+        # The sequences with a continuous reference trajectory
+        view = dataset.match({"has_dense_ground_truth": True})
+
+        session = fo.launch_app(dataset, view=view)
+
+    Dataset size
+        120.67 GB
+    """
+
+    _REPO_ID = "Voxel51/Hilti-SLAM-Challenge-2021"
+    # Pinned so a loaded dataset is reproducible; the default branch is
+    # mutable and could change media, labels or size underneath a user
+    _REVISION = "460f89496379861363aa2c5a969b4712ddfce8eb"
+
+    @property
+    def name(self):
+        return "hilti-slam-challenge-2021"
+
+    @property
+    def license(self):
+        return "CC-BY-NC-SA-3.0"
+
+    @property
+    def tags(self):
+        return ("multimodal", "mcap", "slam", "lidar", "imu")
+
+    @property
+    def supported_splits(self):
+        return None
+
+    def _download_and_prepare(self, dataset_dir, scratch_dir, _):
+        logger.info("Downloading %s from the Hugging Face Hub", self._REPO_ID)
+        hfh.snapshot_download(
+            repo_id=self._REPO_ID,
+            repo_type="dataset",
+            revision=self._REVISION,
+            local_dir=dataset_dir,
+        )
+
+        logger.info("Parsing dataset metadata")
+        dataset_type = fot.FiftyOneDataset()
+        importer = foud.FiftyOneDatasetImporter
+        num_samples = importer._get_num_samples(dataset_dir)
+        logger.info("Found %d samples", num_samples)
+
+        return dataset_type, num_samples, None
+
+
 AVAILABLE_DATASETS = {
     "activitynet-100": ActivityNet100Dataset,
     "activitynet-200": ActivityNet200Dataset,
@@ -3737,6 +3816,7 @@ AVAILABLE_DATASETS = {
     "coco-2017": COCO2017Dataset,
     "egocentric-emg-force": EgocentricEMGForceDataset,
     "fiw": FIWDataset,
+    "hilti-slam-challenge-2021": HiltiSLAMChallenge2021Dataset,
     "hmdb51": HMDB51Dataset,
     "imagenet-sample": ImageNetSampleDataset,
     "kinetics-400": Kinetics400Dataset,


### PR DESCRIPTION
Adds `hilti-slam-challenge-2021` to the dataset zoo, backed by
[Voxel51/Hilti-SLAM-Challenge-2021](https://huggingface.co/datasets/Voxel51/Hilti-SLAM-Challenge-2021)
at a pinned revision.

The first of the Hilti SLAM challenges and the one with the densest sensor
suite. Twelve handheld sequences run through offices, a lab, basements, a
parking deck, campuses and construction sites, chosen for bare corridors
with almost no structure, illumination that changes between floors and
outdoors, stairs, and long loops. The rig is a surveying pole carrying a
Sevensense Alphasense head with five global-shutter cameras at 1440x1080
and an inertial unit, an Ouster OS0-64 spinning LiDAR, a Livox MID70
solid-state LiDAR and an ADIS16445 inertial unit, with every clock agreed
to within a millisecond. Two LiDARs sampling the same scene on one clock is
what sets this year apart.

The episodes are native multimodal MCAP: five camera streams with their
intrinsics, both LiDARs as `foxglove.PointCloud`, the three inertial units
as timeline plots, the reference trajectory both as a timed track and as
poses or surveyed marks, and the rig's calibrated frame tree on `/tf`.
Ten sequences carry sparse 3-DoF references from a total station and two
carry a continuous 6-DoF trajectory from an Optitrack system.

120.67 GB across 12 episodes, 57m 49s of recording. Released under
CC BY-NC-SA 3.0 and redistributed under the same license.

Loaded and read back through `load_from_hub` in the teams image: the repo
resolves, carries `media_type: multimodal`, and every stream the App's MCAP
reader enumerates matches what the samples claim.

This lands in the same alphabetical slot as #8435, so whichever merges
second will need a trivial conflict resolution in `AVAILABLE_DATASETS`.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4114
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for downloading the Hilti SLAM Challenge 2021 dataset from the FiftyOne Dataset Zoo.
  - The dataset is available under the key `hilti-slam-challenge-2021`.
  - Added dataset metadata, including its license, multimodal SLAM tags, and sample count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->