### PR TITLE
Document native rotated bounding box support

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -3290,6 +3290,14 @@ width/height, and counter-clockwise rotation, in radians.
 
 .. note::
 
+    "Counter-clockwise" here and "clockwise as displayed" above describe the
+    **same** rotation: a positive angle rotates counter-clockwise in standard
+    math coordinates (y-axis up) and clockwise on screen in image coordinates
+    (y-axis down). The same angle value produces the same rendered box through
+    either API.
+
+.. note::
+
     FiftyOne stores vertex coordinates as floats in `[0, 1]` relative to the
     dimensions of the image.
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -3251,7 +3251,39 @@ Rotated bounding boxes
     :oss_version: 0.20.0
     :enterprise_version: 1.2
 
-You can store and visualize rotated bounding boxes in FiftyOne using the
+You can represent a rotated (oriented) bounding box natively by adding a
+scalar ``rotation`` attribute to a 2D |Detection|:
+
+.. code-block:: python
+    :linenos:
+
+    import math
+
+    import fiftyone as fo
+
+    detection = fo.Detection(
+        label="vehicle",
+        bounding_box=[0.4, 0.4, 0.2, 0.2],
+        rotation=math.pi / 4,  # radians
+    )
+
+The ``rotation`` defines the angle in ``[0, 2 * pi)`` that the box is rotated
+around its center, applied in pixel space, where positive values rotate the
+box clockwise as displayed. The ``bounding_box`` continues to describe the
+unrotated box.
+
+The App renders rotated detections natively, and in
+:ref:`annotate mode <annotate-tab>` a selected box provides a rotate
+handle (hold ``Shift`` to snap to 15° increments). For video datasets,
+rotation is interpolated between keyframes along the shortest arc.
+
+.. note::
+
+    Rotation is ignored for detections with
+    :ref:`instance masks <instance-segmentation>`, which are stored relative
+    to the unrotated box.
+
+Alternatively, you can represent rotated boxes as polylines using the
 :meth:`Polyline.from_rotated_box() <fiftyone.core.labels.Polyline.from_rotated_box>`
 method, which accepts rotated boxes described by their center coordinates,
 width/height, and counter-clockwise rotation, in radians.

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -443,7 +443,9 @@ class Detection(_HasAttributesDict, _HasID, _HasMedia, _HasInstance, Label):
     -   For :ref:`2D objects <object-detection>`, you must provide the
         ``bounding_box`` parameter, and you can also provide the optional
         ``mask`` or ``mask_path`` parameters to represent
-        :ref:`instance segmentations <instance-segmentation>`
+        :ref:`instance segmentations <instance-segmentation>`, or a scalar
+        ``rotation`` attribute to represent
+        :ref:`rotated bounding boxes <rotated-bounding-boxes>`
     -   For :ref:`3D objects <3d-detections>`, you must instead provide the
         ``location``, ``dimensions``, and ``rotation`` parameters
 
@@ -464,8 +466,11 @@ class Detection(_HasAttributesDict, _HasID, _HasMedia, _HasInstance, Label):
             (3D only)
         dimensions (None): the object size ``[x, y, z]`` in scene units
             (3D only)
-        rotation (None): the object rotation ``[x, y, z]`` around its center,
-            in ``[-pi, pi]`` (3D only)
+        rotation (None): the object's rotation around its center. For 2D
+            objects, a scalar rotation in radians in ``[0, 2 * pi)``, applied
+            in pixel space, where positive values rotate clockwise as
+            displayed; ignored when the detection has an instance mask. For
+            3D objects, an ``[x, y, z]`` rotation in ``[-pi, pi]``
         confidence (None): a confidence in ``[0, 1]`` for the detection
         index (None): an index for the object
         instance (None): an instance of :class:`Instance` to link this


### PR DESCRIPTION
## 🔗 Related Issues

No related GitHub issues to link. Jira: [FOEPD-4586](https://voxel51.atlassian.net/browse/FOEPD-4586). Documents the feature implemented in #8448.

## 📋 What changes are proposed in this pull request?

Docs for the native rotated (oriented) bounding box support added in #8448:

- User guide (`using_datasets.rst`): a native `rotation` example on 2D `Detection`, the convention (radians in `[0, 2*pi)`, applied in pixel space around the box center, positive = clockwise as displayed), App behavior (rendering, annotate-mode rotate handle, shortest-arc video keyframe interpolation), and a note that rotation is ignored for detections with instance masks.
- A note reconciling the `Polyline.from_rotated_box()` docstring's "counter-clockwise" with this section's "clockwise as displayed": both describe the same rotation, viewed in y-up math coordinates vs y-down image coordinates.
- `Detection` docstring (`labels.py`): the `rotation` parameter now documents both the 2D scalar and the existing 3D `[x, y, z]` forms.

## 🧪 How is this patch tested? If it is not, please explain why.

Docs-only change, no tests. The documented convention matches the implementation in #8448, where it is pinned by unit tests (`rotated-box.test.ts`, `DetectionOverlay.test.ts`) and e2e specs.

## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release
      notes for FiftyOne users.

N/A — the feature itself is release-noted in #8448.

### What areas of FiftyOne does this PR affect?

- [ ] App: FiftyOne application changes
- [ ] Build: Build and test infrastructure changes
- [x] Core: Core `fiftyone` Python library changes
- [x] Documentation: FiftyOne documentation changes
- [ ] Other

[FOEPD-4586]: https://voxel51.atlassian.net/browse/FOEPD-4586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4117
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented native support for rotated 2D bounding boxes using a scalar rotation value.
  * Clarified rotation angle conventions, App rendering and editing behavior, and video interpolation.
  * Documented the limitation for detections with instance masks.
  * Clarified that 3D detections use vector rotations and that the polyline-based representation remains available as an alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->