### PR TITLE
Add the SpectralWaste segmentation dataset to the dataset zoo

### DIFF
--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -3726,6 +3726,82 @@ class RoboLabDataset(FiftyOneDataset):
         return dataset_type, num_samples, None
 
 
+class SpectralWasteSegmentationDataset(FiftyOneDataset):
+    """The labeled split of SpectralWaste, as a grouped RGB and
+    hyperspectral dataset.
+
+    The frames come from a working waste-sorting plant, looking down at the
+    conveyor as material passes. Each is captured twice over, once in
+    colour and once by a shortwave infrared camera reading 224 bands from
+    about 900 to 1700 nm. Material that looks identical in colour separates
+    in the infrared, which is what makes the pairing worth having.
+
+    Each sample is a group of three slices: ``rgb``, the colour frame;
+    ``hsi``, a false-colour rendering of the cube built from three bands
+    across the sensor's range; and ``cube``, the 224-band cube itself as a
+    TIFF. The two viewable slices each carry a segmentation mask over six
+    waste categories.
+
+    The release draws its annotations on the colour frame and transfers
+    them onto the hyperspectral one. Every sample carries
+    ``mask_agreement``, how far the two foregrounds overlap, which runs
+    high for the bulky categories and low for the thin ones.
+
+    Example usage::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("spectralwaste-segmentation")
+
+        # Frames where the transferred mask held
+        view = dataset.match({"mask_agreement": {"$gte": 0.7}})
+
+        session = fo.launch_app(dataset, view=view)
+
+    Dataset size
+        25.25 GB
+    """
+
+    _REPO_ID = "Voxel51/SpectralWaste-Segmentation"
+    # Pinned so a loaded dataset is reproducible; the default branch is
+    # mutable and could change media, labels or size underneath a user
+    _REVISION = "2a39311aa1e3d7c511ff9c1941265e6b654415de"
+
+    @property
+    def name(self):
+        return "spectralwaste-segmentation"
+
+    @property
+    def license(self):
+        return "CC-BY-4.0"
+
+    @property
+    def tags(self):
+        return ("multimodal", "hyperspectral", "segmentation", "robotics")
+
+    @property
+    def supported_splits(self):
+        return None
+
+    def _download_and_prepare(self, dataset_dir, scratch_dir, _):
+        logger.info("Downloading %s from the Hugging Face Hub", self._REPO_ID)
+        hfh.snapshot_download(
+            repo_id=self._REPO_ID,
+            repo_type="dataset",
+            revision=self._REVISION,
+            local_dir=dataset_dir,
+        )
+
+        logger.info("Parsing dataset metadata")
+        dataset_type = fot.FiftyOneDataset()
+        importer = foud.FiftyOneDatasetImporter
+        num_samples = importer._get_num_samples(dataset_dir)
+        logger.info("Found %d samples", num_samples)
+
+        return dataset_type, num_samples, None
+
+
 AVAILABLE_DATASETS = {
     "activitynet-100": ActivityNet100Dataset,
     "activitynet-200": ActivityNet200Dataset,
@@ -3758,6 +3834,7 @@ AVAILABLE_DATASETS = {
     "quickstart-3d": Quickstart3DDataset,
     "robolab": RoboLabDataset,
     "sama-coco": SamaCOCODataset,
+    "spectralwaste-segmentation": SpectralWasteSegmentationDataset,
     "tii-ratm-drone-racing": TIIRATMDroneRacingDataset,
     "ucf101": UCF101Dataset,
 }


### PR DESCRIPTION
Adds `spectralwaste-segmentation` to the dataset zoo, backed by
[Voxel51/SpectralWaste-Segmentation](https://huggingface.co/datasets/Voxel51/SpectralWaste-Segmentation)
at a pinned revision.

The labeled split of [SpectralWaste](https://arxiv.org/abs/2403.18033), from
IROS 2024. The frames come from a working waste-sorting plant, looking down
at the conveyor as material passes, and each is captured twice over: once in
colour and once by a shortwave infrared camera reading 224 bands from about
900 to 1700 nm. Material that looks identical in colour separates in the
infrared, which is the point of the pairing. A black basket against black
plastic is nearly invisible in one and obvious in the other.

852 annotated frames from 88 acquisition sessions recorded between September
2022 and June 2023, with six waste categories drawn over them. Each sample is
a group of three slices: `rgb`, the colour frame; `hsi`, a false-colour
rendering built from three bands across the sensor's range; and `cube`, the
224-band cube itself as a TIFF. The two viewable slices each carry a
segmentation mask.

This is the org's first hyperspectral dataset. It is also not a time series,
so it is published as a grouped image dataset rather than as MCAP episodes.

The release annotates the colour frame and transfers the result onto the
hyperspectral one rather than labelling the infrared independently. Every
sample carries `mask_agreement`, the overlap between the two foregrounds, so
a view can exclude the frames where that transfer failed. It depends almost
entirely on object size: on frames holding a single category the median runs
0.90 for `cardboard`, 0.84 for `film`, 0.82 for `basket` and 0.81 for `bag`,
against 0.39 for `video_tape` and 0.27 for `filament`, and it correlates with
the annotated share of the frame at 0.44. A few pixels of misalignment costs
a thin strand its whole overlap and barely touches a bag.

Samples also carry `classes`, `num_classes`, `class_coverage`,
`labeled_fraction`, `sequence_id`, `recorded` and `split`, all computed from
the masks during conversion.

25.25 GB across 852 groups. Released under CC BY 4.0 and redistributed under
the same license. The release's 6,801 unannotated frames are not
republished; they are another 201 GB of cubes with nothing to browse or
evaluate against, and the source's sharded WebDataset form serves a training
loop better than this one would.

Loaded back through `load_from_hub` in the teams image, where the repo
resolves, returns `media_type: group` with all three slices, both mask sets
resolve against the class IDs the release defines, and the cube reads back as
`(224, 256, 256) uint16`.

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4119
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the SpectralWaste Segmentation dataset to the dataset catalog.
  * Supports grouped RGB and hyperspectral waste-segmentation data.
  * Automatically downloads and prepares the dataset for use.
  * Includes dataset metadata, licensing information, and supported splits.
  * Provides sample-count information after dataset preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->