### PR TITLE
Add PortalView primitive with new prompt placements

### DIFF
--- a/app/packages/core/src/plugins/OperatorIO/utils/index.ts
+++ b/app/packages/core/src/plugins/OperatorIO/utils/index.ts
@@ -24,7 +24,7 @@ const outputComponentsByType = {
   File: "FileExplorerView",
   UploadedFile: "FileView",
 };
-const baseViews = ["View", "PromptView", "DrawerView"];
+const baseViews = ["View", "PromptView", "DrawerView", "PortalView"];
 const viewAliases = {
   Button: "ButtonView",
   Dropdown: "DropdownView",

--- a/app/packages/operators/src/OperatorPrompt/OperatorDrawerPrompt.tsx
+++ b/app/packages/operators/src/OperatorPrompt/OperatorDrawerPrompt.tsx
@@ -1,12 +1,7 @@
-import { Resizable, scrollable } from "@fiftyone/components";
-import { Close } from "@mui/icons-material";
-import { Box, IconButton, Stack } from "@mui/material";
+import { Resizable } from "@fiftyone/components";
 import { useState } from "react";
-import OperatorPromptBody from "../components/OperatorPromptBody";
-import OperatorPromptFooter from "../components/OperatorPromptFooter";
-import OperatorPromptHeader from "../components/OperatorPromptHeader";
+import OperatorPromptFrame from "../components/OperatorPromptFrame";
 import { OperatorPromptPropsType } from "../types";
-import { getOperatorPromptConfigs } from "../utils";
 
 const DEFAULT_WIDTH = 250;
 const RIGHT_RESIZE_PLACEMENTS = ["left", "sample-view-left"];
@@ -14,7 +9,6 @@ const RIGHT_RESIZE_PLACEMENTS = ["left", "sample-view-left"];
 export default function OperatorDrawerPrompt(props: OperatorPromptPropsType) {
   const { prompt } = props;
   const [width, setWidth] = useState(DEFAULT_WIDTH);
-  const { title, ...otherConfigs } = getOperatorPromptConfigs(prompt);
   const placement = prompt?.promptView?.placement;
   const direction = RIGHT_RESIZE_PLACEMENTS.includes(placement)
     ? "right"
@@ -34,32 +28,10 @@ export default function OperatorDrawerPrompt(props: OperatorPromptPropsType) {
       }}
       data-cy="operators-prompt-drawer"
     >
-      <IconButton
-        onClick={prompt.close}
-        sx={{ position: "absolute", top: 0, right: 0 }}
-      >
-        <Close />
-      </IconButton>
-      <Box sx={{ p: 1 }}>
-        <OperatorPromptHeader title={title} />
-      </Box>
-      <Box
-        data-cy="operators-prompt-drawer-content"
-        sx={{ overflow: "auto" }}
-        className={scrollable}
-      >
-        <OperatorPromptBody operatorPrompt={prompt} />
-      </Box>
-      <Stack
-        direction="row"
-        spacing={1}
-        justifyContent="center"
-        alignItems="center"
-        data-cy="operators-prompt-drawer-footer"
-        sx={{ py: 1 }}
-      >
-        <OperatorPromptFooter {...otherConfigs} />
-      </Stack>
+      <OperatorPromptFrame
+        prompt={prompt}
+        dataCyPrefix="operators-prompt-drawer"
+      />
     </Resizable>
   );
 }

--- a/app/packages/operators/src/OperatorPrompt/OperatorFullScreenPrompt.tsx
+++ b/app/packages/operators/src/OperatorPrompt/OperatorFullScreenPrompt.tsx
@@ -1,0 +1,42 @@
+import { Card } from "@voxel51/voodo";
+import { useCallback, useEffect } from "react";
+import OperatorPromptFrame from "../components/OperatorPromptFrame";
+import { OperatorPromptPropsType } from "../types";
+
+export default function OperatorFullScreenPrompt(
+  props: OperatorPromptPropsType,
+) {
+  const { prompt } = props;
+
+  const keyDownHandler = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") prompt.close();
+    },
+    [prompt],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", keyDownHandler);
+    return () => {
+      document.removeEventListener("keydown", keyDownHandler);
+    };
+  }, [keyDownHandler]);
+
+  return (
+    <Card
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 9999,
+        borderRadius: 0,
+      }}
+      data-cy="operators-prompt-full-screen"
+    >
+      <OperatorPromptFrame
+        prompt={prompt}
+        dataCyPrefix="operators-prompt-full-screen"
+        contentStyle={{ maxHeight: "calc(100vh - 120px)" }}
+      />
+    </Card>
+  );
+}

--- a/app/packages/operators/src/OperatorPrompt/OperatorPopoverPrompt.tsx
+++ b/app/packages/operators/src/OperatorPrompt/OperatorPopoverPrompt.tsx
@@ -1,0 +1,36 @@
+import { ClickAwayListener } from "@mui/material";
+import { Card } from "@voxel51/voodo";
+import OperatorPromptFrame from "../components/OperatorPromptFrame";
+import { OperatorPromptPropsType } from "../types";
+
+export default function OperatorPopoverPrompt(props: OperatorPromptPropsType) {
+  const { prompt } = props;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        zIndex: 9999,
+        width: "100%",
+        maxWidth: "min(400px, 90vw)",
+        maxHeight: "90vh",
+      }}
+    >
+      <ClickAwayListener onClickAway={prompt.close}>
+        <Card
+          style={{ position: "relative", minWidth: 250 }}
+          data-cy="operators-prompt-popover"
+        >
+          <OperatorPromptFrame
+            prompt={prompt}
+            dataCyPrefix="operators-prompt-popover"
+            contentStyle={{ maxHeight: "calc(90vh - 120px)" }}
+          />
+        </Card>
+      </ClickAwayListener>
+    </div>
+  );
+}

--- a/app/packages/operators/src/OperatorPrompt/index.tsx
+++ b/app/packages/operators/src/OperatorPrompt/index.tsx
@@ -2,10 +2,12 @@ import { createPortal } from "react-dom";
 import { useRecoilValue } from "recoil";
 import { showOperatorPromptSelector, useOperatorPrompt } from "../state";
 import { BaseStylesProvider } from "../styled-components";
-import { OperatorPromptType } from "../types";
+import { PromptArea } from "../types";
+import { OPERATOR_PROMPT_AREAS } from "../constants";
 import OperatorModalPrompt from "./OperatorModalPrompt";
 import OperatorDrawerPrompt from "./OperatorDrawerPrompt";
-import { OPERATOR_PROMPT_AREAS } from "../constants";
+import OperatorPopoverPrompt from "./OperatorPopoverPrompt";
+import OperatorFullScreenPrompt from "./OperatorFullScreenPrompt";
 
 export default function OperatorPrompt() {
   const show = useRecoilValue(showOperatorPromptSelector);
@@ -22,36 +24,36 @@ export default function OperatorPrompt() {
 
 function DynamicOperatorPrompt() {
   const prompt = useOperatorPrompt();
-  const target = getPromptTarget(prompt);
-  const Component = getPromptComponent(prompt);
+  const target = getPromptTarget(prompt.promptView?.target);
+  const Component = getPromptComponent(prompt.promptView?.target);
 
   return createPortal(<Component prompt={prompt} />, target);
 }
 
 const defaultTargetResolver = () => document.body;
-const targetResolverByName = {
-  DrawerView: (promptView: OperatorPromptType["promptView"]) => {
-    const promptArea =
-      promptView.placement === "left"
-        ? OPERATOR_PROMPT_AREAS.DRAWER_LEFT
-        : OPERATOR_PROMPT_AREAS.DRAWER_RIGHT;
-    return document.getElementById(promptArea);
-  },
+const targetResolverByTarget = {
+  [PromptArea.DrawerLeft]: () =>
+    document.getElementById(OPERATOR_PROMPT_AREAS.DRAWER_LEFT),
+  [PromptArea.DrawerRight]: () =>
+    document.getElementById(OPERATOR_PROMPT_AREAS.DRAWER_RIGHT),
+  [PromptArea.Popover]: () => document.body,
+  [PromptArea.FullScreen]: () => document.body,
 };
-export function getPromptTarget(operatorPrompt: OperatorPromptType) {
-  const { promptView } = operatorPrompt;
+export function getPromptTarget(target: string | undefined) {
   const targetResolver =
-    targetResolverByName[promptView?.name] || defaultTargetResolver;
-  return targetResolver(promptView);
+    targetResolverByTarget[target] || defaultTargetResolver;
+  return targetResolver();
 }
 
 const defaultPromptComponentResolver = () => OperatorModalPrompt;
-const promptComponentByName = {
-  DrawerView: () => OperatorDrawerPrompt,
+const promptComponentByTarget = {
+  [PromptArea.DrawerLeft]: () => OperatorDrawerPrompt,
+  [PromptArea.DrawerRight]: () => OperatorDrawerPrompt,
+  [PromptArea.Popover]: () => OperatorPopoverPrompt,
+  [PromptArea.FullScreen]: () => OperatorFullScreenPrompt,
 };
-export function getPromptComponent(operatorPrompt: OperatorPromptType) {
-  const { promptView } = operatorPrompt;
-  const targetResolver =
-    promptComponentByName[promptView?.name] || defaultPromptComponentResolver;
-  return targetResolver(promptView);
+export function getPromptComponent(target: string | undefined) {
+  const componentResolver =
+    promptComponentByTarget[target] || defaultPromptComponentResolver;
+  return componentResolver();
 }

--- a/app/packages/operators/src/components/OperatorPromptFrame.tsx
+++ b/app/packages/operators/src/components/OperatorPromptFrame.tsx
@@ -1,0 +1,63 @@
+import { scrollable } from "@fiftyone/components";
+import {
+  Align,
+  Clickable,
+  Icon,
+  IconName,
+  Justify,
+  Orientation,
+  Size,
+  Spacing,
+  Stack,
+  TextColor,
+} from "@voxel51/voodo";
+import { CSSProperties } from "react";
+import { OperatorPromptType } from "../types";
+import { getOperatorPromptConfigs } from "../utils";
+import OperatorPromptBody from "./OperatorPromptBody";
+import OperatorPromptFooter from "./OperatorPromptFooter";
+import OperatorPromptHeader from "./OperatorPromptHeader";
+
+export default function OperatorPromptFrame(props: {
+  prompt: OperatorPromptType;
+  dataCyPrefix: string;
+  contentStyle?: CSSProperties;
+}) {
+  const { prompt, dataCyPrefix, contentStyle } = props;
+  const { title, ...otherConfigs } = getOperatorPromptConfigs(prompt);
+
+  return (
+    <>
+      <Clickable
+        onClick={prompt.close}
+        style={{ position: "absolute", top: 0, right: 0, padding: 8 }}
+      >
+        <Icon
+          name={IconName.Close}
+          size={Size.Sm}
+          color={TextColor.Secondary}
+        />
+      </Clickable>
+      <Stack style={{ padding: 8 }}>
+        <OperatorPromptHeader title={title} />
+      </Stack>
+      <div
+        data-cy={`${dataCyPrefix}-content`}
+        style={{ overflow: "auto", ...contentStyle }}
+        className={scrollable}
+      >
+        <OperatorPromptBody operatorPrompt={prompt} />
+      </div>
+      <Stack
+        orientation={Orientation.Row}
+        spacing={Spacing.Sm}
+        justify={Justify.Center}
+        align={Align.Center}
+        data-cy={`${dataCyPrefix}-footer`}
+        style={{ paddingTop: 8, paddingBottom: 8 }}
+      >
+        <OperatorPromptFooter {...otherConfigs} />
+      </Stack>
+    </>
+  );
+}

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -596,6 +596,7 @@ type ViewProps = {
   caption?: string;
   space?: number;
   name?: string;
+  target?: string;
   [key: string]: ViewPropertyTypes;
 };
 
@@ -610,6 +611,7 @@ export class View {
     this.caption = options.caption;
     this.space = options.space;
     this.componentsProps = options.componentsProps;
+    this.target = options.target;
     this.name = "View";
     this.options = options;
   }
@@ -619,6 +621,7 @@ export class View {
   space?: number;
   name?: string;
   componentsProps?: unknown;
+  target?: string;
   static fromJSON(json: ViewProps) {
     return new View(json);
   }
@@ -1368,6 +1371,13 @@ export enum Places {
   MAP_SECONDARY_ACTIONS = "map-secondary-actions",
   DISPLAY_OPTIONS = "display-options",
   HEADER_ACTIONS = "header-actions",
+}
+
+export enum PromptArea {
+  DrawerLeft = "drawer-left",
+  DrawerRight = "drawer-right",
+  Popover = "popover",
+  FullScreen = "full-screen",
 }
 
 // NOTE: keys should always match fiftyone/operators/types.py

--- a/app/packages/operators/src/utils.test.ts
+++ b/app/packages/operators/src/utils.test.ts
@@ -267,6 +267,22 @@ describe("getOperatorPromptConfigs", () => {
     expect(customPrompt).toBeNull();
     expect(customPromptName).toBeUndefined();
   });
+
+  it("hides onSubmit and onCancel when promptView.show_actions is false", () => {
+    const onSubmit = vi.fn();
+    const cancel = vi.fn();
+    const configs = getOperatorPromptConfigs(
+      createOperatorPromptOptions({
+        showPrompt: true,
+        onSubmit,
+        cancel,
+        inputFields: { view: {} },
+        promptView: { show_actions: false },
+      }),
+    );
+    expect(configs.onSubmit).toBeUndefined();
+    expect(configs.onCancel).toBeUndefined();
+  });
 });
 
 function createOperatorPromptOptions(

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -71,9 +71,11 @@ export function getOperatorPromptConfigs(operatorPrompt: OperatorPromptType) {
     }
   }
 
+  const showActions = customPrompt?.show_actions !== false;
+
   if (operatorPrompt.showPrompt) {
-    onSubmit = operatorPrompt.onSubmit;
-    onCancel = operatorPrompt.cancel;
+    onSubmit = showActions ? operatorPrompt.onSubmit : undefined;
+    onCancel = showActions ? operatorPrompt.cancel : undefined;
   } else if (showResultOrError) {
     onCancel = operatorPrompt.close;
     cancelButtonText = "Close";

--- a/fiftyone/operators/_types/types.py
+++ b/fiftyone/operators/_types/types.py
@@ -1315,6 +1315,7 @@ class View(object):
         componentsProps (None): dict for providing props to components rendered
             by a view
         container (None): the container (instance of :class:`BaseType`) of the view
+        show_actions (True): whether to show the prompt's submit/cancel actions
     """
 
     def __init__(self, container=None, **kwargs):
@@ -1327,6 +1328,7 @@ class View(object):
         self.component = kwargs.get("component", None)
         self.componentsProps = kwargs.get("componentsProps", None)
         self.container = container
+        self.show_actions = kwargs.get("show_actions", True)
         self._kwargs = kwargs
 
     def clone(self):
@@ -1350,6 +1352,7 @@ class View(object):
             "container": (
                 self.container.to_json() if self.container else None
             ),
+            "show_actions": self.show_actions,
             **self.kwargs_to_json(),
         }
 
@@ -3342,7 +3345,53 @@ class DashboardView(View):
         }
 
 
-class DrawerView(View):
+class PromptArea(enum.Enum):
+    """The areas available for placing an operator prompt in the FiftyOne
+    App.
+    """
+
+    DRAWER_LEFT = "drawer-left"
+    DRAWER_RIGHT = "drawer-right"
+    POPOVER = "popover"
+    FULL_SCREEN = "full-screen"
+
+    def to_json(self):
+        return self.value
+
+
+class PortalView(View):
+    """Renders an operator prompt in a named area of the FiftyOne App,
+    rather than the default modal.
+
+    Examples::
+
+        import fiftyone.operators.types as types
+
+        # in resolve_input
+        inputs = types.Object()
+        inputs.str("message", label="Message")
+        prompt = types.PortalView(target=types.PromptArea.POPOVER)
+        return types.Property(inputs, view=prompt)
+
+    Args:
+        target: a :class:`PromptArea` value specifying where to render the
+            prompt
+    """
+
+    def __init__(self, target=None, **kwargs):
+        if not isinstance(target, PromptArea):
+            raise ValueError(
+                "target must be a PromptArea value, found %r" % (target,)
+            )
+
+        super().__init__(**kwargs)
+        self.target = target
+
+    def to_json(self):
+        return {**super().to_json(), "target": self.target.to_json()}
+
+
+class DrawerView(PortalView):
     """Renders an operator prompt as a left or right side drawer.
 
     Examples::
@@ -3367,7 +3416,13 @@ class DrawerView(View):
         placement = kwargs.get("placement", None)
         if placement not in ["left", "right"]:
             raise ValueError('placement must be either "left" or "right".')
-        super().__init__(**kwargs)
+
+        target = (
+            PromptArea.DRAWER_LEFT
+            if placement == "left"
+            else PromptArea.DRAWER_RIGHT
+        )
+        super().__init__(target=target, **kwargs)
 
 
 class IconButtonView(Button):

--- a/tests/unittests/operators/types_tests.py
+++ b/tests/unittests/operators/types_tests.py
@@ -205,3 +205,54 @@ class TestTextFieldViewType(unittest.TestCase):
 
         self.assertTrue(view_json["multiline"])
         self.assertEqual(view_json["rows"], 5)
+
+
+class TestViewType(unittest.TestCase):
+    def test_show_actions_defaults_true(self):
+        self.assertTrue(types.View().to_json()["show_actions"])
+
+    def test_show_actions_false(self):
+        view = types.View(show_actions=False)
+        self.assertFalse(view.to_json()["show_actions"])
+
+
+class TestPortalViewType(unittest.TestCase):
+    def test_serialize_target(self):
+        view = types.PortalView(target=types.PromptArea.POPOVER)
+
+        dict_rep = view.to_json()
+
+        self.assertEqual(dict_rep["name"], "PortalView")
+        self.assertEqual(dict_rep["target"], "popover")
+
+    def test_serialize_full_screen_target(self):
+        view = types.PortalView(target=types.PromptArea.FULL_SCREEN)
+
+        self.assertEqual(view.to_json()["target"], "full-screen")
+
+    def test_invalid_target_raises(self):
+        with self.assertRaises(ValueError):
+            types.PortalView(target="popover")
+
+    def test_component_passthrough(self):
+        view = types.PortalView(
+            target=types.PromptArea.POPOVER, component="CustomComponent"
+        )
+
+        self.assertEqual(view.to_json()["component"], "CustomComponent")
+
+
+class TestDrawerViewType(unittest.TestCase):
+    def test_serialize_is_backwards_compatible(self):
+        for placement, target in [
+            ("left", "drawer-left"),
+            ("right", "drawer-right"),
+        ]:
+            dict_rep = types.DrawerView(placement=placement).to_json()
+            self.assertEqual(dict_rep["name"], "DrawerView")
+            self.assertEqual(dict_rep["placement"], placement)
+            self.assertEqual(dict_rep["target"], target)
+
+    def test_invalid_placement_raises(self):
+        with self.assertRaises(ValueError):
+            types.DrawerView(placement="up")


### PR DESCRIPTION
## 🔗 Related Issues

No related issues to link.

## 📋 What changes are proposed in this pull request?

This PR adds a new `PortalView` primitive with four placements:

* `DRAWER_LEFT`
* `DRAWER_RIGHT`
* `POPOVER`
* `FULL_SCREEN`

`DrawerView` now extends `PortalView`, keeping the current API and behavior. It also extracts a shared `OperatorPromptFrame`, so all prompt types use the same UI and behavior.

Finally, this adds `show_actions` to `View`. This is useful for hybrid plugins using `component=` that handle their own actions and don't need the default **Cancel** and **Execute** buttons.

## 🧪 How is this patch tested? If it is not, please explain why.

Manually tested Drawer left/right, Popover, Full Screen, and `show_actions`

https://github.com/user-attachments/assets/a9e39967-191b-4245-a229-e9547ceb945a


## 📝 Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* [ ] No
* [x] Yes

Operator prompts now support drawer, popover, and full-screen views. Hybrid plugins can also hide the default prompt actions.

### What areas of FiftyOne does this PR affect?

* [x] App: FiftyOne application changes
* [ ] Build: Build and test infrastructure changes
* [x] Core: Core `fiftyone` Python library changes
* [ ] Documentation: FiftyOne documentation changes
* [ ] Other

<!-- enterprise-sync-pr:start -->
---
**Enterprise sync PR**: https://github.com/voxel51/fiftyone-teams/pull/4120
<!-- enterprise-sync-pr:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added popover and fullscreen display options for operator prompts.
  - Prompts can now appear in named application areas, including left and right drawers.
  - Added a consistent prompt layout with shared headers, content, close controls, and footers.
- **Improvements**
  - Prompt actions can now be hidden when configured.
  - Clicking outside a popover closes the prompt.
- **Bug Fixes**
  - Improved consistency across drawer-based operator prompt layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->